### PR TITLE
Add pulling of images that are not present

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,9 +140,13 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	exec.sendStatus(TaskRunning, taskInfo.GetTaskId())
 
+	log.Info("Using image '%s'", *taskInfo.Container.Docker.Image)
+
 	// TODO implement configurable pull timeout?
-	if *taskInfo.Container.Docker.ForcePullImage {
+	if !container.CheckImage(exec.client, taskInfo) || *taskInfo.Container.Docker.ForcePullImage {
 		container.PullImage(exec.client, taskInfo)
+	} else {
+		log.Info("Re-using existing image... already present")
 	}
 
 	// Configure and create the container


### PR DESCRIPTION
This should replicate the default behavior of the Docker client which will pull an image that is not present. We will still pull an image if force pull is enabled, even if it's present already.

sidekick @felixgborrego 