### PR TITLE
Improve image pulls, add auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ the Docker container. Currently the settings available are:
 	SidecarBackoff:      1m5s
 	SidecarPollInterval: 30s
 	SidecarMaxFails:     3
+	DockerRepository:    https://index.docker.io/v1/
 ```
 
 All of the environment variables are of the form `EXECUTOR_SIDECAR_RETRY_DELAY`
@@ -128,6 +129,11 @@ with `EXECUTOR_`.
    the container? Note that this is not just _contacting_ Sidecar. This is how
    many _affirmed_ unhealthy checks we need to receive, each spaced apart by
    `SidecarPollInterval`.
+
+ * **DockerRepository**: This is used to match the credentials that we'll store
+   from the Docker config. This will follow the same matching order as
+   [described here](https://godoc.org/github.com/fsouza/go-dockerclient#NewAuthConfigurationsFromDockerCfg).
+   The executor expects to use only one set of credentials for each job.
 
 Contributing
 ------------

--- a/callbacks.go
+++ b/callbacks.go
@@ -38,7 +38,12 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// TODO implement configurable pull timeout?
 	if !container.CheckImage(exec.client, taskInfo) || *taskInfo.Container.Docker.ForcePullImage {
-		container.PullImage(exec.client, taskInfo)
+		err := container.PullImage(exec.client, taskInfo)
+		if err != nil {
+			log.Errorf("Failed to pull image: %s", err.Error())
+			exec.failTask(taskInfo)
+			return
+		}
 	} else {
 		log.Info("Re-using existing image... already present")
 	}

--- a/callbacks.go
+++ b/callbacks.go
@@ -3,6 +3,7 @@ package main
 import (
 	"time"
 
+	"github.com/fsouza/go-dockerclient"
 	"github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/nitro/sidecar-executor/container"
@@ -38,7 +39,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// TODO implement configurable pull timeout?
 	if !container.CheckImage(exec.client, taskInfo) || *taskInfo.Container.Docker.ForcePullImage {
-		err := container.PullImage(exec.client, taskInfo)
+		err := container.PullImage(exec.client, taskInfo, &docker.AuthConfiguration{})
 		if err != nil {
 			log.Errorf("Failed to pull image: %s", err.Error())
 			exec.failTask(taskInfo)

--- a/container/container.go
+++ b/container/container.go
@@ -63,13 +63,15 @@ func StopContainer(client DockerClient, containerId string, timeout uint) error 
 	return nil
 }
 
-// Pull the Docker image refered to in the taskInfo
-func PullImage(client DockerClient, taskInfo *mesos.TaskInfo) error {
+// Pull the Docker image refered to in the taskInfo. Uses the Docker
+// credentials passed in.
+func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker.AuthConfiguration) error {
 	log.Infof("Pulling Docker image '%s'", *taskInfo.Container.Docker.Image)
-	err := client.PullImage(docker.PullImageOptions{
+	err := client.PullImage(
+		docker.PullImageOptions{
 			Repository: *taskInfo.Container.Docker.Image,
 		},
-		docker.AuthConfiguration{},
+		*authConfig,
 	)
 	if err != nil {
 		return err

--- a/container/container.go
+++ b/container/container.go
@@ -64,14 +64,20 @@ func StopContainer(client DockerClient, containerId string, timeout uint) error 
 }
 
 // Pull the Docker image refered to in the taskInfo
-func PullImage(client DockerClient, taskInfo *mesos.TaskInfo) {
+func PullImage(client DockerClient, taskInfo *mesos.TaskInfo) error {
 	log.Infof("Pulling Docker image '%s'", *taskInfo.Container.Docker.Image)
-	client.PullImage(docker.PullImageOptions{
-		Repository: *taskInfo.Container.Docker.Image,
-	},
+	err := client.PullImage(docker.PullImageOptions{
+			Repository: *taskInfo.Container.Docker.Image,
+		},
 		docker.AuthConfiguration{},
 	)
+	if err != nil {
+		return err
+	}
+
 	log.Info("Pulled.")
+
+	return nil
 }
 
 // Generate a complete config with both Config and HostConfig. Does not attempt

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 type mockDockerClient struct {
-	ValidOptions                bool
+	validOptions                bool
+	PullImageShouldError        bool
 	Images                      []docker.APIImages
 	ListImagesShouldError       bool
 	StopContainerShouldError    bool
@@ -21,8 +22,12 @@ type mockDockerClient struct {
 }
 
 func (m *mockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
+	if m.PullImageShouldError {
+		return errors.New("Something went wrong!")
+	}
+
 	if len(opts.Repository) > 5 && (docker.AuthConfiguration{}) == auth {
-		m.ValidOptions = true
+		m.validOptions = true
 	}
 
 	return nil
@@ -59,7 +64,7 @@ func (m *mockDockerClient) InspectContainer(id string) (*docker.Container, error
 }
 
 func Test_PullImage(t *testing.T) {
-	Convey("PullImage() passes the right params", t, func() {
+	Convey("PullImage()", t, func() {
 		image := "foo/foo:foo"
 		taskInfo := &mesos.TaskInfo{
 			Container: &mesos.ContainerInfo{
@@ -70,9 +75,21 @@ func Test_PullImage(t *testing.T) {
 		}
 
 		dockerClient := &mockDockerClient{}
-		PullImage(dockerClient, taskInfo)
 
-		So(dockerClient.ValidOptions, ShouldBeTrue)
+		Convey("passes the right params", func() {
+			err := PullImage(dockerClient, taskInfo)
+
+			So(dockerClient.validOptions, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("bubbles up errors", func() {
+			dockerClient.PullImageShouldError = true
+			err := PullImage(dockerClient, taskInfo)
+
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "Something went wrong")
+		})
 	})
 }
 

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -77,7 +77,7 @@ func Test_PullImage(t *testing.T) {
 		dockerClient := &mockDockerClient{}
 
 		Convey("passes the right params", func() {
-			err := PullImage(dockerClient, taskInfo)
+			err := PullImage(dockerClient, taskInfo, &docker.AuthConfiguration{})
 
 			So(dockerClient.validOptions, ShouldBeTrue)
 			So(err, ShouldBeNil)
@@ -85,7 +85,7 @@ func Test_PullImage(t *testing.T) {
 
 		Convey("bubbles up errors", func() {
 			dockerClient.PullImageShouldError = true
-			err := PullImage(dockerClient, taskInfo)
+			err := PullImage(dockerClient, taskInfo, &docker.AuthConfiguration{})
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Something went wrong")


### PR DESCRIPTION
This should add both error handling for image pulls and Docker auth. It takes the approach that the executor should be told which set of credentials to use by configuring the name of the repository in the environment rather than parsing apart the image string that is passed.

This has been tested to not break the existing public image pulls but needs to be verified against a private repo.