### PR TITLE
Make sure we kill the task on health failure!

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,6 +234,7 @@ func (exec *sidecarExecutor) sidecarStatus(container *docker.Container) error {
 	for i := 0; i < config.SidecarRetryCount; i++ {
 		data, err = fetch()
 		if err != nil {
+			log.Warnf("Failed %d health checks!", i)
 			time.Sleep(config.SidecarRetryDelay)
 			continue
 		}


### PR DESCRIPTION
The Sidecar integration was good at noticing issues and exiting the executor. Not so much for killing off the task. So that meant that cranky services were leaving around lots of containers! Bad News™. So this should fix it by actually killing off the task when the health checks are all failed.