### PR TITLE
Copy logs to stdout/stderr on failure

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"os"
 	"time"
 
@@ -33,18 +32,10 @@ func (exec *sidecarExecutor) Disconnected(driver executor.ExecutorDriver) {
 // from the Mesos API.
 func (exec *sidecarExecutor) copyLogs(taskId string) {
 	startTimeEpoch := time.Now().UTC().Add(0-config.LogsSince).Unix()
-	stdout, stderr := container.GetLogs(exec.client, taskId, startTimeEpoch)
 
-	// We don't know how much we're reading (or care), so ignore length
-	_, err := io.Copy(os.Stdout, stdout)
-	if err != nil {
-		log.Errorf("Failed to fetch stdout from container: %s", err.Error())
-	}
-
-	_, err = io.Copy(os.Stderr, stderr)
-	if err != nil {
-		log.Errorf("Failed to fetch stderr from container: %s", err.Error())
-	}
+	container.GetLogs(
+		exec.client, taskId, startTimeEpoch, os.Stdout, os.Stderr,
+	)
 }
 
 // monitorTask runs in a goroutine and hangs out, waiting for the watchLooper to

--- a/container/container.go
+++ b/container/container.go
@@ -86,13 +86,13 @@ func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker
 
 // Fetch the Docker logs from a task and return two Readers that let
 // us fetch the contents.
-func GetLogs(client DockerClient, taskInfo *mesos.TaskInfo, since int64) (stdout io.Reader, stderr io.Reader) {
+func GetLogs(client DockerClient, taskId string, since int64) (stdout io.Reader, stderr io.Reader) {
 	stdoutR, stdoutW := io.Pipe()
 	stderrR, stderrW := io.Pipe()
 
 	go func() {
 		err := client.Logs(docker.LogsOptions{
-			Container:    *taskInfo.TaskId.Value,
+			Container:    taskId,
 			OutputStream: stdoutW,
 			ErrorStream:  stderrW,
 			Since:        since,

--- a/container/container.go
+++ b/container/container.go
@@ -96,6 +96,8 @@ func GetLogs(client DockerClient, taskInfo *mesos.TaskInfo, since int64) (stdout
 			OutputStream: stdoutW,
 			ErrorStream:  stderrW,
 			Since:        since,
+			Stdout:       true,
+			Stderr:       true,
 		})
 
 		if err != nil {

--- a/container/container.go
+++ b/container/container.go
@@ -86,15 +86,12 @@ func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker
 
 // Fetch the Docker logs from a task and return two Readers that let
 // us fetch the contents.
-func GetLogs(client DockerClient, taskId string, since int64) (stdout io.Reader, stderr io.Reader) {
-	stdoutR, stdoutW := io.Pipe()
-	stderrR, stderrW := io.Pipe()
-
+func GetLogs(client DockerClient, taskId string, since int64, stdout io.Writer, stderr io.Writer) {
 	go func() {
 		err := client.Logs(docker.LogsOptions{
 			Container:    taskId,
-			OutputStream: stdoutW,
-			ErrorStream:  stderrW,
+			OutputStream: stdout,
+			ErrorStream:  stderr,
 			Since:        since,
 			Stdout:       true,
 			Stderr:       true,
@@ -104,9 +101,6 @@ func GetLogs(client DockerClient, taskId string, since int64) (stdout io.Reader,
 			log.Errorf("Failed to fetch logs for task: %s", err.Error())
 		}
 	}()
-
-	// Regardless of what happens we return these to be read
-	return stdoutR, stderrR
 }
 
 // Generate a complete config with both Config and HostConfig. Does not attempt

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -183,11 +183,8 @@ func Test_GetLogs(t *testing.T) {
 	Convey("Fetches the logs from a task", t, func() {
 		taskId := "nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
 		dockerClient := &mockDockerClient{}
-		taskInfo := &mesos.TaskInfo{
-			TaskId: &mesos.TaskID{Value: &taskId},
-		}
 
-		stdout, stderr := GetLogs(dockerClient, taskInfo, time.Now().UTC().Unix())
+		stdout, stderr := GetLogs(dockerClient, taskId, time.Now().UTC().Unix())
 		output, _ := ioutil.ReadAll(stdout)
 		errout, _ := ioutil.ReadAll(stderr)
 

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -26,6 +26,7 @@ type mockDockerClient struct {
 	stopContainerFails          int
 	StopContainerMaxFails       int
 	InspectContainerShouldError bool
+	logOpts                     *docker.LogsOptions
 	Container                   *docker.Container
 }
 
@@ -72,6 +73,7 @@ func (m *mockDockerClient) InspectContainer(id string) (*docker.Container, error
 }
 
 func (m *mockDockerClient) Logs(opts docker.LogsOptions) error {
+	m.logOpts = &opts
 	opts.OutputStream.Write([]byte(prelude))
 	opts.OutputStream.(*io.PipeWriter).Close()
 	opts.ErrorStream.Write([]byte(ending))
@@ -191,6 +193,10 @@ func Test_GetLogs(t *testing.T) {
 
 		So(string(output), ShouldEqual, prelude)
 		So(string(errout), ShouldEqual, ending)
+
+		So(dockerClient.logOpts.Stdout, ShouldBeTrue)
+		So(dockerClient.logOpts.OutputStream, ShouldNotBeNil)
+		So(dockerClient.logOpts.ErrorStream, ShouldNotBeNil)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type Config struct {
 	SidecarPollInterval time.Duration `split_words:"true" default:"30s"`
 	SidecarMaxFails     int           `split_words:"true" default:"3"`
 	DockerRepository    string        `split_words:"true" default:"https://index.docker.io/v1/"`
+	LogsSince           time.Duration `split_words:"true" default:"3m"`
 }
 
 type sidecarExecutor struct {
@@ -81,6 +82,7 @@ func logConfig() {
 	log.Infof(" * SidecarPollInterval: %s", config.SidecarPollInterval.String())
 	log.Infof(" * SidecarMaxFails:     %d", config.SidecarMaxFails)
 	log.Infof(" * DockerRepository:    %s", config.DockerRepository)
+	log.Infof(" * LogsSince:           %s", config.LogsSince.String())
 
 	log.Infof("Environment ---------------------------")
 	for _, setting := range os.Environ() {


### PR DESCRIPTION
This should grab the logs from stdout and stderr on the docker container, and copy them to the executor's stdout and stderr. That then relays them to Mesos, so we can fetch them from the API and for example, display them on failed deployment.

sidekick @felixgborrego 