### PR TITLE
Fairly extensively test the interactions with Sidecar

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -114,7 +114,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// We have to do this in a different goroutine or the scheduler
 	// can't send us any further updates.
-	go exec.watchContainer(cntnr)
+	go exec.watchContainer(cntnr.ID)
 	go exec.monitorTask(cntnr.ID[:12], taskInfo)
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -13,11 +13,14 @@ import (
 
 // Our own narrowly-scoped interface for Docker client
 type DockerClient interface {
-	PullImage(docker.PullImageOptions, docker.AuthConfiguration) error
-	ListImages(docker.ListImagesOptions) ([]docker.APIImages, error)
-	StopContainer(id string, timeout uint) error
+	CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error)
 	InspectContainer(id string) (*docker.Container, error)
+	ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error)
+	ListImages(docker.ListImagesOptions) ([]docker.APIImages, error)
 	Logs(opts docker.LogsOptions) error
+	PullImage(docker.PullImageOptions, docker.AuthConfiguration) error
+	StartContainer(id string, hostConfig *docker.HostConfig) error
+	StopContainer(id string, timeout uint) error
 }
 
 // Loop through all the images and see if we have one with a match

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -2,9 +2,11 @@ package container
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	. "github.com/smartystreets/goconvey/convey"
@@ -15,8 +17,13 @@ const (
 	ending  = "Thus made their mourning the men of Geatland, for their hero's passing his hearth-companions"
 )
 
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
 func Test_PullImage(t *testing.T) {
 	Convey("PullImage()", t, func() {
+
 		image := "foo/foo:foo"
 		taskInfo := &mesos.TaskInfo{
 			Container: &mesos.ContainerInfo{
@@ -117,7 +124,7 @@ func Test_GetLogs(t *testing.T) {
 		taskId := "nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
 		dockerClient := &MockDockerClient{
 			LogOutputString: prelude,
-			LogErrorString: ending,
+			LogErrorString:  ending,
 		}
 
 		stdout := bytes.NewBuffer(make([]byte, 0, 256))

--- a/container/mock_docker_client.go
+++ b/container/mock_docker_client.go
@@ -1,3 +1,4 @@
+// +build ignore
 package container
 
 import (

--- a/container/mock_docker_client.go
+++ b/container/mock_docker_client.go
@@ -20,11 +20,12 @@ type MockDockerClient struct {
 	Container                   *docker.Container
 	LogOutputString             string
 	LogErrorString              string
+	ListContainersShouldError   bool
 }
 
 func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
 	if m.PullImageShouldError {
-		return errors.New("Something went wrong!")
+		return errors.New("Something went wrong! [PullImage()]")
 	}
 
 	if len(opts.Repository) > 5 && (docker.AuthConfiguration{}) == auth {
@@ -36,7 +37,7 @@ func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.A
 
 func (m *MockDockerClient) ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error) {
 	if m.ListImagesShouldError {
-		return nil, errors.New("Something went wrong!")
+		return nil, errors.New("Something went wrong! [ListImages()]")
 	}
 	return m.Images, nil
 }
@@ -46,7 +47,7 @@ func (m *MockDockerClient) StopContainer(id string, timeout uint) error {
 		m.stopContainerFails += 1
 
 		if m.stopContainerFails > m.StopContainerMaxFails {
-			return errors.New("Something went wrong!")
+			return errors.New("Something went wrong! [StopContainer()]")
 		}
 	}
 	return nil
@@ -54,14 +55,14 @@ func (m *MockDockerClient) StopContainer(id string, timeout uint) error {
 
 func (m *MockDockerClient) InspectContainer(id string) (*docker.Container, error) {
 	if m.InspectContainerShouldError {
-		return nil, errors.New("Something went wrong!")
+		return nil, errors.New("Something went wrong! [InspectContainer()]")
 	}
 
 	if m.Container != nil {
 		return m.Container, nil
 	}
 
-	return nil, errors.New("Forgot to set the mock container!")
+	return nil, errors.New("Forgot to set the mock container! [InspectContainer()]")
 }
 
 func (m *MockDockerClient) Logs(opts docker.LogsOptions) error {
@@ -81,5 +82,8 @@ func (m *MockDockerClient) StartContainer(id string, hostConfig *docker.HostConf
 }
 
 func (m *MockDockerClient) ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error) {
-	return nil, nil
+	if m.ListContainersShouldError {
+		return nil, errors.New("Something went wrong! [ListContainers()]")
+	}
+	return []docker.APIContainers{}, nil
 }

--- a/container/mock_docker_client.go
+++ b/container/mock_docker_client.go
@@ -1,0 +1,84 @@
+package container
+
+import (
+	"errors"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+type MockDockerClient struct {
+	validOptions                bool
+	PullImageShouldError        bool
+	Images                      []docker.APIImages
+	ListImagesShouldError       bool
+	StopContainerShouldError    bool
+	stopContainerFails          int
+	StopContainerMaxFails       int
+	InspectContainerShouldError bool
+	logOpts                     *docker.LogsOptions
+	Container                   *docker.Container
+	LogOutputString             string
+	LogErrorString              string
+}
+
+func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
+	if m.PullImageShouldError {
+		return errors.New("Something went wrong!")
+	}
+
+	if len(opts.Repository) > 5 && (docker.AuthConfiguration{}) == auth {
+		m.validOptions = true
+	}
+
+	return nil
+}
+
+func (m *MockDockerClient) ListImages(opts docker.ListImagesOptions) ([]docker.APIImages, error) {
+	if m.ListImagesShouldError {
+		return nil, errors.New("Something went wrong!")
+	}
+	return m.Images, nil
+}
+
+func (m *MockDockerClient) StopContainer(id string, timeout uint) error {
+	if m.StopContainerShouldError {
+		m.stopContainerFails += 1
+
+		if m.stopContainerFails > m.StopContainerMaxFails {
+			return errors.New("Something went wrong!")
+		}
+	}
+	return nil
+}
+
+func (m *MockDockerClient) InspectContainer(id string) (*docker.Container, error) {
+	if m.InspectContainerShouldError {
+		return nil, errors.New("Something went wrong!")
+	}
+
+	if m.Container != nil {
+		return m.Container, nil
+	}
+
+	return nil, errors.New("Forgot to set the mock container!")
+}
+
+func (m *MockDockerClient) Logs(opts docker.LogsOptions) error {
+	m.logOpts = &opts
+	opts.OutputStream.Write([]byte(m.LogOutputString))
+	opts.ErrorStream.Write([]byte(m.LogErrorString))
+
+	return nil
+}
+
+func (m *MockDockerClient) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
+	return nil, nil
+}
+
+func (m *MockDockerClient) StartContainer(id string, hostConfig *docker.HostConfig) error {
+	return nil
+}
+
+func (m *MockDockerClient) ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error) {
+	return nil, nil
+}

--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func (exec *sidecarExecutor) failTask(taskInfo *mesos.TaskInfo) {
 // Loop on a timed basis and check the health of the process in Sidecar.
 // Note that because of the way the retries work, the loop timing is a
 // lower bound on the delay.
-func (exec *sidecarExecutor) watchContainer(container *docker.Container) {
+func (exec *sidecarExecutor) watchContainer(containerId string) {
 	time.Sleep(config.SidecarBackoff)
 
 	exec.watchLooper.Loop(func() error {
@@ -178,16 +178,17 @@ func (exec *sidecarExecutor) watchContainer(container *docker.Container) {
 		// container with our Id.
 		ok := false
 		for _, entry := range containers {
-			if entry.ID == container.ID {
+			if entry.ID == containerId {
 				ok = true
+				break
 			}
 		}
 		if !ok {
-			return errors.New("Container " + container.ID + " not running!")
+			return errors.New("Container " + containerId + " not running!")
 		}
 
 		// Validate health status with Sidecar
-		if err = exec.sidecarStatus(container.ID); err != nil {
+		if err = exec.sidecarStatus(containerId); err != nil {
 			return err
 		}
 

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ type Config struct {
 
 type sidecarExecutor struct {
 	driver      *executor.MesosExecutorDriver
-	client      *docker.Client
-	httpClient  *http.Client
+	client      container.DockerClient
+	fetcher     SidecarFetcher
 	watchLooper director.Looper
 	dockerAuth  *docker.AuthConfiguration
 	failCount   int
@@ -63,10 +63,14 @@ type SidecarServices struct {
 	}
 }
 
-func newSidecarExecutor(client *docker.Client, auth *docker.AuthConfiguration) *sidecarExecutor {
+type SidecarFetcher interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+func newSidecarExecutor(client container.DockerClient, auth *docker.AuthConfiguration) *sidecarExecutor {
 	return &sidecarExecutor{
 		client:     client,
-		httpClient: &http.Client{Timeout: config.HttpTimeout},
+		fetcher:    &http.Client{Timeout: config.HttpTimeout},
 		dockerAuth: auth,
 	}
 }
@@ -183,7 +187,7 @@ func (exec *sidecarExecutor) watchContainer(container *docker.Container) {
 		}
 
 		// Validate health status with Sidecar
-		if err = exec.sidecarStatus(container); err != nil {
+		if err = exec.sidecarStatus(container.ID); err != nil {
 			return err
 		}
 
@@ -196,6 +200,7 @@ func sidecarLookup(containerId string, services SidecarServices) (*service.Servi
 	hostname := os.Getenv("TASK_HOST") // Mesos supplies this
 	if _, ok := services.Servers[hostname]; !ok {
 		// Don't even have this host!
+		log.Warnf("Host not found in Sidecar! (%s)", hostname)
 		return nil, ok
 	}
 
@@ -210,14 +215,19 @@ func shouldBeKilled(svc *service.Service) bool {
 }
 
 func (exec *sidecarExecutor) exceededFailCount() bool {
-	return exec.failCount < config.SidecarMaxFails
+	return exec.failCount >= config.SidecarMaxFails
 }
 
 // Validate the status of this task with Sidecar
-func (exec *sidecarExecutor) sidecarStatus(container *docker.Container) error {
+func (exec *sidecarExecutor) sidecarStatus(containerId string) error {
 	fetch := func() ([]byte, error) {
-		resp, err := exec.httpClient.Get(config.SidecarUrl)
-		defer resp.Body.Close()
+		resp, err := exec.fetcher.Get(config.SidecarUrl)
+		defer func() {
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}()
+
 		if err != nil {
 			return nil, err
 		}
@@ -233,10 +243,10 @@ func (exec *sidecarExecutor) sidecarStatus(container *docker.Container) error {
 	// Try to connect to Sidecar, with some retries
 	var err error
 	var data []byte
-	for i := 0; i < config.SidecarRetryCount; i++ {
+	for i := 0; i <= config.SidecarRetryCount; i++ {
 		data, err = fetch()
 		if err != nil {
-			log.Warnf("Failed %d health checks!", i)
+			log.Warnf("Failed %d health checks!", i+1)
 			time.Sleep(config.SidecarRetryDelay)
 			continue
 		}
@@ -259,7 +269,7 @@ func (exec *sidecarExecutor) sidecarStatus(container *docker.Container) error {
 		return nil
 	}
 
-	svc, ok := sidecarLookup(container.ID, services)
+	svc, ok := sidecarLookup(containerId, services)
 	if !ok {
 		log.Errorf("Can't find this service in Sidecar yet! Assuming healthy...")
 		return nil
@@ -279,8 +289,10 @@ func (exec *sidecarExecutor) sidecarStatus(container *docker.Container) error {
 		log.Errorf("Health failure count exceeded %d", config.SidecarMaxFails)
 
 		exec.failCount = 0
-		return errors.New("Unhealthy container: " + container.ID + " failing task!")
+		return errors.New("Unhealthy container: " + containerId + " failing task!")
 	}
+
+	exec.failCount = 0 // Reset because we were healthy!
 
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -166,5 +167,30 @@ func Test_sidecarStatus(t *testing.T) {
 			So(result, ShouldBeNil)
 			So(exec.failCount, ShouldEqual, 0)
 		})
+
+		Convey("healthy when the host doesn't exist in Sidecar", func() {
+			os.Setenv("TASK_HOST", "zaragoza")
+			fetcher.ShouldError = false
+
+			So(exec.sidecarStatus("deadbeef0010"), ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_logConfig(t *testing.T) {
+	// We want to make sure we don't forget to print settings when they get added
+	Convey("Logs all the config settings", t, func() {
+		output := bytes.NewBuffer([]byte{})
+
+		os.Setenv("MESOS_LEGEND", "roncevalles")
+
+		log.SetOutput(output) // Don't show the output
+		logConfig()
+
+		v := reflect.ValueOf(config)
+		for i := 0; i < v.NumField(); i++ {
+		    So(string(output.Bytes()), ShouldContainSubstring, v.Type().Field(i).Name)
+		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ type mockFetcher struct {
 	ShouldFail    bool
 	ShouldError   bool
 	ShouldBadJson bool
-	callCount   int
+	callCount     int
 }
 
 func (m *mockFetcher) Get(string) (*http.Response, error) {
@@ -44,13 +44,13 @@ func (m *mockFetcher) Get(string) (*http.Response, error) {
 func (m *mockFetcher) successRequest() (*http.Response, error) {
 	return httpResponse(200, `
 		{
-		    "Servers": {
-		        "roncevalles": {
+			"Servers": {
+				"roncevalles": {
 					"Services": {
 						"deadbeef0010": {
-		            	    "ID": "deadbeef0010",
-		            	    "Status": 0
-		            	}
+							"ID": "deadbeef0010",
+							"Status": 0
+						}
 					}
 				}
 			}
@@ -65,13 +65,13 @@ func (m *mockFetcher) badJson() (*http.Response, error) {
 func (m *mockFetcher) failedRequest() (*http.Response, error) {
 	return httpResponse(500, `
 		{
-		    "Servers": {
-		        "roncevalles": {
+			"Servers": {
+				"roncevalles": {
 					"Services": {
 						"deadbeef0010": {
-		            	    "ID": "deadbeef0010",
-		            	    "Status": 1
-		            	}
+							"ID": "deadbeef0010",
+							"Status": 1
+						}
 					}
 				}
 			}
@@ -190,7 +190,7 @@ func Test_logConfig(t *testing.T) {
 
 		v := reflect.ValueOf(config)
 		for i := 0; i < v.NumField(); i++ {
-		    So(string(output.Bytes()), ShouldContainSubstring, v.Type().Field(i).Name)
+			So(string(output.Bytes()), ShouldContainSubstring, v.Type().Field(i).Name)
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/nitro/sidecar-executor/container"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type mockFetcher struct {
+	ShouldFail    bool
+	ShouldError   bool
+	ShouldBadJson bool
+	callCount   int
+}
+
+func (m *mockFetcher) Get(string) (*http.Response, error) {
+	m.callCount += 1
+
+	if m.ShouldBadJson {
+		return m.badJson()
+	}
+
+	if m.ShouldError {
+		return nil, errors.New("OMG something went horribly wrong!")
+	}
+
+	if m.ShouldFail {
+		return m.failedRequest()
+	} else {
+		return m.successRequest()
+	}
+}
+
+func (m *mockFetcher) successRequest() (*http.Response, error) {
+	return httpResponse(200, `
+		{
+		    "Servers": {
+		        "roncevalles": {
+					"Services": {
+						"deadbeef0010": {
+		            	    "ID": "deadbeef0010",
+		            	    "Status": 0
+		            	}
+					}
+				}
+			}
+		}
+	`), nil
+}
+
+func (m *mockFetcher) badJson() (*http.Response, error) {
+	return httpResponse(200, `OMG invalid JSON`), nil
+}
+
+func (m *mockFetcher) failedRequest() (*http.Response, error) {
+	return httpResponse(500, `
+		{
+		    "Servers": {
+		        "roncevalles": {
+					"Services": {
+						"deadbeef0010": {
+		            	    "ID": "deadbeef0010",
+		            	    "Status": 1
+		            	}
+					}
+				}
+			}
+		}
+	`), nil
+}
+
+func httpResponse(status int, bodyStr string) *http.Response {
+	body := bytes.NewBuffer([]byte(bodyStr))
+
+	return &http.Response{
+		Status:        strconv.Itoa(status),
+		StatusCode:    status,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          ioutil.NopCloser(body),
+		ContentLength: int64(body.Len()),
+	}
+}
+
+func Test_sidecarStatus(t *testing.T) {
+	Convey("When handling Sidecar status", t, func() {
+		log.SetOutput(ioutil.Discard) // Don't show logged errors/warnings/etc
+
+		os.Setenv("TASK_HOST", "roncevalles")
+		fetcher := &mockFetcher{}
+
+		client := &container.MockDockerClient{}
+		exec := newSidecarExecutor(client, &docker.AuthConfiguration{})
+		exec.fetcher = fetcher
+
+		config.SidecarRetryDelay = 0
+		config.SidecarRetryCount = 0
+
+		Convey("return healthy on HTTP request errors", func() {
+			fetcher.ShouldError = true
+
+			So(exec.sidecarStatus("deadbeef0010"), ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 0)
+		})
+
+		Convey("retries as expected", func() {
+			fetcher.ShouldError = true
+			config.SidecarRetryCount = 5
+
+			exec.sidecarStatus("deadbeef0010")
+			So(fetcher.callCount, ShouldEqual, 6) // 1 try + (5 retries)
+		})
+
+		Convey("healthy on JSON parse errors", func() {
+			fetcher.ShouldBadJson = true
+			So(exec.sidecarStatus("deadbeef0010"), ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 0)
+		})
+
+		Convey("errors when it can talk to Sidecar and fail count is exceeded", func() {
+			fetcher.ShouldFail = true
+
+			config.SidecarMaxFails = 3
+			exec.failCount = 3
+
+			result := exec.sidecarStatus("deadbeef0010")
+			So(result, ShouldNotBeNil)
+			So(result.Error(), ShouldContainSubstring, "deadbeef0010 failing task!")
+			So(exec.failCount, ShouldEqual, 0) // Gets reset!
+		})
+
+		Convey("healthy when it can talk to Sidecar and fail count is below limit", func() {
+			fetcher.ShouldFail = true
+
+			config.SidecarMaxFails = 3
+			exec.failCount = 1
+
+			result := exec.sidecarStatus("deadbeef0010")
+			So(result, ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 2)
+		})
+
+		Convey("resets failCount on first healthy response", func() {
+			fetcher.ShouldFail = true
+
+			config.SidecarMaxFails = 3
+			exec.failCount = 1
+
+			result := exec.sidecarStatus("deadbeef0010")
+			So(result, ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 2)
+
+			// Get a healthy response, reset the counter
+			fetcher.ShouldFail = false
+			result = exec.sidecarStatus("deadbeef0010")
+			So(result, ShouldBeNil)
+			So(exec.failCount, ShouldEqual, 0)
+		})
+	})
+}


### PR DESCRIPTION
This adds a bunch of tests around validating health status from Sidecar. Fixes a few bugs that were caught by the tests as well. More testing to come but, this is a good stab at a core part of the functionality. Also breaks out the `MockDockerClient` into an exported type from the `container` module so that we can use it in testing package `main` as well.

cc @felixgborrego @mihaitodor 