### PR TITLE
Notice when containers die

### DIFF
--- a/container/mock_docker_client.go
+++ b/container/mock_docker_client.go
@@ -20,6 +20,7 @@ type MockDockerClient struct {
 	LogOutputString             string
 	LogErrorString              string
 	ListContainersShouldError   bool
+	ListContainersContainers    []docker.APIContainers
 }
 
 func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
@@ -84,5 +85,17 @@ func (m *MockDockerClient) ListContainers(opts docker.ListContainersOptions) ([]
 	if m.ListContainersShouldError {
 		return nil, errors.New("Something went wrong! [ListContainers()]")
 	}
-	return []docker.APIContainers{}, nil
+
+	if opts.All {
+		return m.ListContainersContainers, nil
+	}
+
+	// Simulate the non-All option
+	var containers []docker.APIContainers
+	for _, container := range m.ListContainersContainers {
+		if container.State != "exited" {
+			containers = append(containers, container)
+		}
+	}
+	return containers, nil
 }

--- a/main.go
+++ b/main.go
@@ -170,9 +170,7 @@ func (exec *sidecarExecutor) watchContainer(containerId string) {
 
 	exec.watchLooper.Loop(func() error {
 		containers, err := exec.client.ListContainers(
-			docker.ListContainersOptions{
-				All: true,
-			},
+			docker.ListContainersOptions{},
 		)
 		if err != nil {
 			return err

--- a/main_test.go
+++ b/main_test.go
@@ -263,6 +263,20 @@ func Test_watchContainer(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Container deadbeef0010 not running!")
 		})
+
+		Convey("returns an error when the container exists but has exited", func() {
+			client.ListContainersContainers = []docker.APIContainers{
+				docker.APIContainers{
+					ID: "deadbeef0010",
+					State: "exited",
+				},
+			}
+			exec.watchContainer("deadbeef0010")
+
+			err := <-resultChan
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "Container deadbeef0010 not running!")
+		})
 	})
 }
 


### PR DESCRIPTION
This fixes the bug where the container is killed but the executor didn't notice. The root of the problem is that the `All: true` option was being passed to the Docker client so the dead container was showing up. This adds a test, fixes, the issue, and adds `All: true` support to the `MockDockerClient`.

sidekick @felixgborrego 