### PR TITLE
Fix orphaned containers by using prefix mesos- as a container's name.

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -89,10 +89,10 @@ func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker
 
 // Fetch the Docker logs from a task and return two Readers that let
 // us fetch the contents.
-func GetLogs(client DockerClient, taskId string, since int64, stdout io.Writer, stderr io.Writer) {
+func GetLogs(client DockerClient, containerId string, since int64, stdout io.Writer, stderr io.Writer) {
 	go func() {
 		err := client.Logs(docker.LogsOptions{
-			Container:    taskId,
+			Container:    containerId,
 			OutputStream: stdout,
 			ErrorStream:  stderr,
 			Since:        since,
@@ -110,10 +110,8 @@ func GetLogs(client DockerClient, taskId string, since int64, stdout io.Writer, 
 // to be exhaustive in support for Docker options. Supports the most commonly
 // used options. Others are not complex to add.
 func ConfigForTask(taskInfo *mesos.TaskInfo) *docker.CreateContainerOptions {
-	name := "mesos-" + *taskInfo.TaskId.Value
-
 	config := &docker.CreateContainerOptions{
-		Name: name,
+		Name: GetContainerName(taskInfo.TaskId),
 		Config: &docker.Config{
 			Env:          EnvForTask(taskInfo),
 			ExposedPorts: PortsForTask(taskInfo),
@@ -280,4 +278,13 @@ func getResource(name string, taskInfo *mesos.TaskInfo) *mesos.Resource {
 	}
 
 	return nil
+}
+
+
+// Prefix used to name Docker containers in order to distinguish those
+// created by Mesos from those created manually.
+const DockerNamePrefix = "mesos-"
+
+func GetContainerName(taskId *mesos.TaskID) string {
+	return DockerNamePrefix + *taskId.Value
 }

--- a/container/container.go
+++ b/container/container.go
@@ -110,9 +110,10 @@ func GetLogs(client DockerClient, taskId string, since int64, stdout io.Writer, 
 // to be exhaustive in support for Docker options. Supports the most commonly
 // used options. Others are not complex to add.
 func ConfigForTask(taskInfo *mesos.TaskInfo) *docker.CreateContainerOptions {
+	name := "mesos-" + *taskInfo.TaskId.Value
 
 	config := &docker.CreateContainerOptions{
-		Name: *taskInfo.TaskId.Value,
+		Name: name,
 		Config: &docker.Config{
 			Env:          EnvForTask(taskInfo),
 			ExposedPorts: PortsForTask(taskInfo),

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -121,7 +121,7 @@ func Test_StopContainer(t *testing.T) {
 
 func Test_GetLogs(t *testing.T) {
 	Convey("Fetches the logs from a task", t, func() {
-		taskId := "nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
+		containerId := "mesos-nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
 		dockerClient := &MockDockerClient{
 			LogOutputString: prelude,
 			LogErrorString:  ending,
@@ -130,7 +130,7 @@ func Test_GetLogs(t *testing.T) {
 		stdout := bytes.NewBuffer(make([]byte, 0, 256))
 		stderr := bytes.NewBuffer(make([]byte, 0, 256))
 
-		GetLogs(dockerClient, taskId, time.Now().UTC().Unix(), stdout, stderr)
+		GetLogs(dockerClient, containerId, time.Now().UTC().Unix(), stdout, stderr)
 
 		time.Sleep(1 * time.Millisecond) // Nasty, but lets buffer flush
 
@@ -237,7 +237,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		opts := ConfigForTask(taskInfo)
 
 		Convey("gets the name from the task ID", func() {
-			So(opts.Name, ShouldEqual, taskId)
+			So(opts.Name, ShouldEqual, "mesos-" + taskId)
 		})
 
 		Convey("properly calculates the CPU shares", func() {


### PR DESCRIPTION
When recovering, mesos agent uses the prefix `mesos-` to identify if a task was launch by Mesos.

Ref: `https://github.com/apache/mesos/blob/master/src/slave/containerizer/docker.cpp#L879`

