### PR TITLE
Allow Vault to use env vars.

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func logConfig() {
 	for _, setting := range os.Environ() {
 		if (len(setting) >= 5 && setting[:5] == "MESOS") ||
 			((len(setting) >= 8) && setting[:8] == "EXECUTOR") ||
+			((len(setting) >= 5) && setting[:5] == "VAULT") ||
 			(setting == "HOME") {
 			pair := strings.Split(setting, "=")
 			log.Infof(" * %-25s: %s", pair[0], pair[1])

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -28,7 +28,11 @@ type VaultAPI interface {
 // setting the `VAULT_ADDR` environment variable.
 func NewDefaultVault() EnvVault {
 	conf := api.DefaultConfig()
-	log.Infof("Vault address '%s'", conf.Address)
+	err := conf.ReadEnvironment()
+	if err != nil {
+		log.Warn("Unable to load Environment vars: %s", err.Error())
+	}
+	log.Infof("Vault address '%s' ", conf.Address)
 	vaultClient, _ := api.NewClient(conf)
 	return EnvVault{client: vaultClient}
 }


### PR DESCRIPTION
For instances `VAULT_SKIP_VERIFY`