### PR TITLE
Allow disabling the Sidecar health check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.7.x
   - 1.8.x
-  - master
 
 script:
   - go test -v ./... && (CGO_ENABLED=0 GOOS=linux go build -ldflags '-d')

--- a/callbacks.go
+++ b/callbacks.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"os"
+	"strconv"
 	"time"
 
+	"github.com/Nitro/sidecar-executor/container"
 	log "github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient"
 	"github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
-	"github.com/Nitro/sidecar-executor/container"
 	"github.com/relistan/go-director"
-	"github.com/fsouza/go-dockerclient"
-	"strconv"
 )
 
 // Callbacks from the Mesos driver. These are required to implement

--- a/callbacks.go
+++ b/callbacks.go
@@ -188,11 +188,11 @@ func (exec *sidecarExecutor) Error(driver executor.ExecutorDriver, err string) {
 
 // Check if it should check Sidecar status, assuming enabled by default
 func shouldCheckSidecar(containerConfig *docker.CreateContainerOptions) bool {
-	if _, ok:= containerConfig.Config.Labels["SidecarDiscover"]; !ok {
+	value, ok:= containerConfig.Config.Labels["SidecarDiscover"]
+	if !ok {
 		return true
 	}
 
-	value, _ := containerConfig.Config.Labels["SidecarDiscover"]
 	if enabled, err:= strconv.ParseBool(value); err == nil {
 		return enabled
 	}

--- a/callbacks.go
+++ b/callbacks.go
@@ -9,6 +9,8 @@ import (
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	"github.com/Nitro/sidecar-executor/container"
 	"github.com/relistan/go-director"
+	"github.com/fsouza/go-dockerclient"
+	"strconv"
 )
 
 // Callbacks from the Mesos driver. These are required to implement
@@ -41,9 +43,9 @@ func (exec *sidecarExecutor) copyLogs(containerId string) {
 // monitorTask runs in a goroutine and hangs out, waiting for the watchLooper to
 // complete. When it completes, it handles the Docker and Mesos interactions.
 func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInfo) {
-	log.Infof("Monitoring container %s for Mesos task %s",
-		cntnrId,
+	log.Infof("Monitoring Mesos task %s for container %s",
 		*taskInfo.TaskId.Value,
+		cntnrId,
 	)
 
 	containerName := container.GetContainerName(taskInfo.TaskId)
@@ -63,8 +65,8 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 		return
 	}
 
-	exec.finishTask(taskInfo)
 	log.Info("Task completed: ", taskInfo.GetName())
+	exec.finishTask(taskInfo)
 	return
 }
 
@@ -129,7 +131,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// We have to do this in a different goroutine or the scheduler
 	// can't send us any further updates.
-	go exec.watchContainer(cntnr.ID)
+	go exec.watchContainer(cntnr.ID, shouldCheckSidecar(containerConfig))
 	go exec.monitorTask(cntnr.ID[:12], taskInfo)
 }
 
@@ -182,4 +184,18 @@ func (exec *sidecarExecutor) Shutdown(driver executor.ExecutorDriver) {
 
 func (exec *sidecarExecutor) Error(driver executor.ExecutorDriver, err string) {
 	log.Info("Got error message:", err)
+}
+
+// Check if it should check Sidecar status, assuming enabled by default
+func shouldCheckSidecar(containerConfig *docker.CreateContainerOptions) bool {
+	if _, ok:= containerConfig.Config.Labels["SidecarDiscover"]; !ok {
+		return true
+	}
+
+	value, _ := containerConfig.Config.Labels["SidecarDiscover"]
+	if enabled, err:= strconv.ParseBool(value); err == nil {
+		return enabled
+	}
+
+	return true
 }

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/fsouza/go-dockerclient"
+)
+
+func Test_shouldCheckSidecar(t *testing.T) {
+	Convey("When checking if Sidecar is enabled", t, func() {
+
+		containerOptions := &docker.CreateContainerOptions{
+			Config: &docker.Config{},
+		}
+
+		Convey("shouldCheckSidecar should be true when the label is missing", func() {
+			So(shouldCheckSidecar(containerOptions), ShouldBeTrue)
+		})
+
+		Convey("shouldCheckSidecar should be true when SidecarDiscover=true", func() {
+			containerOptions.Config.Labels = map[string]string{"SidecarDiscover" : "true"}
+
+			So(shouldCheckSidecar(containerOptions), ShouldBeTrue)
+		})
+
+		Convey("shouldCheckSidecar should be false when SidecarDiscover=false", func() {
+			containerOptions.Config.Labels = map[string]string{"SidecarDiscover" : "false"}
+
+			So(shouldCheckSidecar(containerOptions), ShouldBeFalse)
+		})
+	})
+}

--- a/container/container.go
+++ b/container/container.go
@@ -56,6 +56,10 @@ func StopContainer(client DockerClient, containerId string, timeout uint) error 
 		return err
 	}
 
+	if cntr.State.Status == "exited" {
+		return nil // Already stopped, nothing to do
+	}
+
 	err = client.StopContainer(containerId, timeout)
 	if err != nil {
 		return err

--- a/container/container.go
+++ b/container/container.go
@@ -292,3 +292,11 @@ const DockerNamePrefix = "mesos-"
 func GetContainerName(taskId *mesos.TaskID) string {
 	return DockerNamePrefix + *taskId.Value
 }
+
+func GetExitCode(client DockerClient, containerId string) (int, error) {
+	inspect, err := client.InspectContainer(containerId)
+	if err != nil {
+		return 0, fmt.Errorf("Container %s not found! - %s", containerId, err.Error())
+	}
+	return inspect.State.ExitCode, nil
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/relistan/envconfig"
 	"github.com/relistan/go-director"
 	"github.com/Nitro/sidecar-executor/vault"
+	"fmt"
 )
 
 const (
@@ -169,8 +170,11 @@ func (exec *sidecarExecutor) failTask(taskInfo *mesos.TaskInfo) {
 // Loop on a timed basis and check the health of the process in Sidecar.
 // Note that because of the way the retries work, the loop timing is a
 // lower bound on the delay.
-func (exec *sidecarExecutor) watchContainer(containerId string) {
-	time.Sleep(config.SidecarBackoff)
+func (exec *sidecarExecutor) watchContainer(containerId string, checkSidecar bool) {
+	log.Infof("Watching container %s [checkSidecar: %t]", containerId, checkSidecar)
+	if checkSidecar {
+		time.Sleep(config.SidecarBackoff)
+	}
 
 	exec.watchLooper.Loop(func() error {
 		containers, err := exec.client.ListContainers(
@@ -180,7 +184,7 @@ func (exec *sidecarExecutor) watchContainer(containerId string) {
 			return err
 		}
 
-		// Loop through all the containers, looking for a running
+		// Loop through all the running containers, looking for a running
 		// container with our Id.
 		ok := false
 		for _, entry := range containers {
@@ -190,7 +194,24 @@ func (exec *sidecarExecutor) watchContainer(containerId string) {
 			}
 		}
 		if !ok {
-			return errors.New("Container " + containerId + " not running!")
+			// The container is not running, try to fetch the exist reason
+			inspect, err := exec.client.InspectContainer(containerId)
+			if err != nil {
+				return fmt.Errorf("Container %s not found! - %s", containerId, err.Error())
+			}
+
+			msg := fmt.Sprintf("Container %s not running! - Status: %s , ExitCode: %d", containerId, inspect.State.Status, inspect.State.ExitCode)
+			if inspect.State.ExitCode == 0 {
+				log.Infof(msg)
+				exec.watchLooper.Done(nil)
+				return nil
+			} else {
+				return errors.New(msg)
+			}
+		}
+
+		if !checkSidecar {
+			return nil
 		}
 
 		// Validate health status with Sidecar

--- a/main.go
+++ b/main.go
@@ -205,9 +205,9 @@ func (exec *sidecarExecutor) watchContainer(containerId string, checkSidecar boo
 				log.Infof(msg)
 				exec.watchLooper.Done(nil)
 				return nil
-			} else {
-				return errors.New(msg)
 			}
+
+			return errors.New(msg)
 		}
 
 		if !checkSidecar {

--- a/main.go
+++ b/main.go
@@ -194,14 +194,14 @@ func (exec *sidecarExecutor) watchContainer(containerId string, checkSidecar boo
 			}
 		}
 		if !ok {
-			// The container is not running, try to fetch the exist reason
-			inspect, err := exec.client.InspectContainer(containerId)
+			exitCode, err := container.GetExitCode(exec.client, containerId)
+
 			if err != nil {
-				return fmt.Errorf("Container %s not found! - %s", containerId, err.Error())
+				return err
 			}
 
-			msg := fmt.Sprintf("Container %s not running! - Status: %s , ExitCode: %d", containerId, inspect.State.Status, inspect.State.ExitCode)
-			if inspect.State.ExitCode == 0 {
+			msg := fmt.Sprintf("Container %s not running! - ExitCode: %d", containerId, exitCode)
+			if exitCode == 0 {
 				log.Infof(msg)
 				exec.watchLooper.Done(nil)
 				return nil


### PR DESCRIPTION
When the container is labelled as `SidecarDiscover: false` there is no need for checking the status in Sidecar, this change also allows us to run tasks no integrated with Sidecar.