### PR TITLE
Add support for memory and CPU CFS (Completely Fair Scheduler) limits

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -95,7 +95,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 	}
 
 	// Configure the container
-	containerConfig := container.ConfigForTask(taskInfo)
+	containerConfig := container.ConfigForTask(taskInfo, exec.config.ForceCpuLimit, exec.config.ForceMemoryLimit)
 
 	// Try to decrypt any existing Vault encoded env.
 	decryptedEnv, err := exec.vault.DecryptAllEnv(containerConfig.Config.Env)
@@ -116,7 +116,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// Start the container
 	log.Info("Starting container with ID " + cntnr.ID[:12])
-	err = exec.client.StartContainer(cntnr.ID, containerConfig.HostConfig)
+	err = exec.client.StartContainer(cntnr.ID, nil)
 	if err != nil {
 		log.Errorf("Failed to create Docker container: %s", err.Error())
 		exec.failTask(taskInfo)

--- a/container/container.go
+++ b/container/container.go
@@ -11,6 +11,10 @@ import (
 	mesos "github.com/mesos/mesos-go/mesosproto"
 )
 
+// Using a small period (50ms) to ensure a consistency latency response at the expense of burst capacity
+// See: https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+const defaultCpuPeriod = 50000 // 50ms microseconds
+
 // Our own narrowly-scoped interface for Docker client
 type DockerClient interface {
 	CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error)
@@ -109,10 +113,6 @@ func GetLogs(client DockerClient, containerId string, since int64, stdout io.Wri
 		}
 	}()
 }
-
-// Using a small period (50ms) to ensure a consistency latency response at the expense of burst capacity
-// See: https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
-const defaultCpuPeriod = 50000 // 50ms microseconds
 
 // Generate a complete config with both Config and HostConfig. Does not attempt
 // to be exhaustive in support for Docker options. Supports the most commonly


### PR DESCRIPTION

The limit is not enforced by default and must be manually enabled with `EXECUTOR_FORCE_MEMORY_LIMIT` and `EXECUTOR_FORCE_CPU_LIMIT`.

This is equivalent to the docker run parameters : `--cpu-period` and `--cpu-quota`,  more info at: https://docs.docker.com/engine/reference/run/#cpu-period-constraint