### PR TITLE
Add port mappings  and hostname to Docker environment

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -205,6 +205,11 @@ func EnvForTask(taskInfo *mesos.TaskInfo) []string {
 		)
 	}
 
+	// We must also expose the external hostname into the container
+	// so that tasks can know their public hostname. Otherwise they
+	// only know about their container ID as the hostname per Docker.
+	envVars = append(envVars, "MESOS_HOSTNAME=" + *taskInfo.Container.Hostname)
+
 	return envVars
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -191,6 +191,20 @@ func EnvForTask(taskInfo *mesos.TaskInfo) []string {
 		envVars = append(envVars, *param.Value)
 	}
 
+	// Expose port mappings to the container via env vars. This
+	// lets the container know its externally-facing ports for
+	// purposes of reporting to other services, etc.
+	for _, port := range taskInfo.Container.Docker.PortMappings {
+		if port.ContainerPort == nil || port.HostPort == nil {
+			continue
+		}
+
+		envVars = append(
+			envVars,
+			fmt.Sprintf("MESOS_PORT_%d=%d", *port.ContainerPort, *port.HostPort),
+		)
+	}
+
 	return envVars
 }
 

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -255,8 +255,12 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("populates the environment", func() {
-			So(len(opts.Config.Env), ShouldEqual, 1)
+			So(len(opts.Config.Env), ShouldBeGreaterThan, 1)
 			So(opts.Config.Env[0], ShouldEqual, "SOMETHING=123=123")
+		})
+
+		Convey("maps ports into the environment", func() {
+			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "MESOS_PORT_=")
 		})
 
 		Convey("fills in the exposed ports", func() {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -176,6 +176,8 @@ func Test_ConfigGeneration(t *testing.T) {
 		v2_hp := "/tmp/bar"
 		mode := mesos.Volume_RO
 
+		hostname := "beowulf.example.com"
+
 		taskInfo := &mesos.TaskInfo{
 			TaskId: &mesos.TaskID{Value: &taskId},
 			Container: &mesos.ContainerInfo{
@@ -221,6 +223,7 @@ func Test_ConfigGeneration(t *testing.T) {
 						HostPath:      &v2_hp,
 					},
 				},
+				Hostname: &hostname,
 			},
 			Resources: []*mesos.Resource{
 				{
@@ -260,7 +263,11 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("maps ports into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "MESOS_PORT_=")
+			So(opts.Config.Env[len(opts.Config.Env)-2], ShouldEqual, "MESOS_PORT_443=10270")
+		})
+
+		Convey("maps the hostname into the environment", func() {
+			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "MESOS_HOSTNAME=" + hostname)
 		})
 
 		Convey("fills in the exposed ports", func() {


### PR DESCRIPTION
This change will expose the port mappings and Docker/Mesos worker hostname into the container for each service. This is useful for services which need to be able to share their public port/hostname information with other nodes (e.g. via gossip protocols). The `MESOS_` prefix was chosen since the Mesos `TaskInfo` struct is the source of the information, as opposed to Docker.  Docker in configured by the executor using this same information, so it will match.