### PR TITLE
Add service, env name, and version to env vars for services

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -75,8 +75,6 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 	log.Infof("Launching task %s with command '%s'", taskInfo.GetName(), taskInfo.Command.GetValue())
 	log.Info("Task ID ", taskInfo.GetTaskId().GetValue())
 
-	logTaskEnv(taskInfo)
-
 	// We need to tell the scheduler that we started the task
 	exec.sendStatus(TaskRunning, taskInfo.GetTaskId())
 
@@ -96,6 +94,9 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 
 	// Configure the container
 	containerConfig := container.ConfigForTask(taskInfo, exec.config.ForceCpuLimit, exec.config.ForceMemoryLimit)
+
+	// Log out what we're starting up with
+	logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
 
 	// Try to decrypt any existing Vault encoded env.
 	decryptedEnv, err := exec.vault.DecryptAllEnv(containerConfig.Config.Env)

--- a/container/container.go
+++ b/container/container.go
@@ -265,6 +265,14 @@ func EnvForTask(taskInfo *mesos.TaskInfo, labels map[string]string) []string {
 	envVars = append(envVars, "SERVICE_NAME="+svcName)
 	envVars = append(envVars, "ENVIRONMENT_NAME="+envName)
 
+	// We parse out and expose the version from the Docker tag as well
+	versionParts := strings.Split(*taskInfo.Container.Docker.Image, ":")
+	if len(versionParts) < 2 {
+		envVars = append(envVars, "SERVICE_VERSION=latest")
+	} else {
+		envVars = append(envVars, "SERVICE_VERSION="+versionParts[1])
+	}
+
 	return envVars
 }
 

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -54,7 +54,7 @@ func Test_PullImage(t *testing.T) {
 
 func Test_CheckImage(t *testing.T) {
 	Convey("CheckImage()", t, func() {
-		image := "gonitro/sidecar:latest"
+		image := "gonitro/sidecar:1.0.0"
 		images := []docker.APIImages{
 			{
 				RepoTags: []string{image, "sidecar", "sidecar:latest"},
@@ -149,7 +149,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		// The whole structure is full of pointers, so we have to define
 		// a bunch of things so we can take their address.
 		taskId := "nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
-		image := "foo/foo:foo"
+		image := "foo/foo:1.0.0"
 		cpus := "cpus"
 		cpusValue := float64(0.5)
 		memory := "mem"
@@ -290,19 +290,23 @@ func Test_ConfigGeneration(t *testing.T) {
 
 		Convey("maps ports into the environment", func() {
 			// We index backward to find the vars we just set
-			So(opts.Config.Env[len(opts.Config.Env)-4], ShouldEqual, "MESOS_PORT_443=10270")
+			So(opts.Config.Env[len(opts.Config.Env)-5], ShouldEqual, "MESOS_PORT_443=10270")
 		})
 
 		Convey("maps the hostname into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-3], ShouldEqual, "MESOS_HOSTNAME="+hostname)
+			So(opts.Config.Env[len(opts.Config.Env)-4], ShouldEqual, "MESOS_HOSTNAME="+hostname)
 		})
 
 		Convey("maps the ServiceName into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-2], ShouldEqual, "SERVICE_NAME="+svcName)
+			So(opts.Config.Env[len(opts.Config.Env)-3], ShouldEqual, "SERVICE_NAME="+svcName)
 		})
 
 		Convey("maps the EnvironmentName into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "ENVIRONMENT_NAME="+envName)
+			So(opts.Config.Env[len(opts.Config.Env)-2], ShouldEqual, "ENVIRONMENT_NAME="+envName)
+		})
+
+		Convey("maps the version into the environment", func() {
+			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "SERVICE_VERSION=1.0.0")
 		})
 
 		Convey("fills in the exposed ports", func() {

--- a/main.go
+++ b/main.go
@@ -117,8 +117,8 @@ func logConfig() {
 	log.Infof("---------------------------------------")
 }
 
-func logTaskEnv(taskInfo *mesos.TaskInfo) {
-	env := container.EnvForTask(taskInfo)
+func logTaskEnv(taskInfo *mesos.TaskInfo, labels map[string]string) {
+	env := container.EnvForTask(taskInfo, labels)
 	if len(env) < 1 {
 		log.Info("No Docker environment provided")
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -226,18 +226,19 @@ func Test_logTaskEnv(t *testing.T) {
 		}
 
 		Convey("dumps the vars it finds", func() {
-			logTaskEnv(taskInfo)
+			logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
 
 			So(string(output.Bytes()), ShouldContainSubstring, "--------")
 			So(string(output.Bytes()), ShouldContainSubstring, "BOCACCIO=author")
 		})
 
-		Convey("reports when there are none", func() {
+		Convey("always has environment and service name", func() {
 			taskInfo.Container.Docker.Parameters = []*mesos.Parameter{}
 
-			logTaskEnv(taskInfo)
+			logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
 
-			So(string(output.Bytes()), ShouldContainSubstring, "No Docker environment")
+			So(string(output.Bytes()), ShouldContainSubstring, "SERVICE_NAME=undefined-servicename")
+			So(string(output.Bytes()), ShouldContainSubstring, "ENVIRONMENT_NAME=")
 		})
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Nitro/sidecar-executor/container"
 	log "github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
 	mesos "github.com/mesos/mesos-go/mesosproto"
-	"github.com/Nitro/sidecar-executor/container"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -232,14 +232,44 @@ func Test_logTaskEnv(t *testing.T) {
 			So(string(output.Bytes()), ShouldContainSubstring, "BOCACCIO=author")
 		})
 
-		Convey("always has environment and service name", func() {
+		Convey("has environment and service name if defined", func() {
+			key := "label"
+			svcName := "ServiceName=test-service"
+			envName := "EnvironmentName=dev"
+			taskInfo.Container.Docker.Parameters = []*mesos.Parameter{
+				{
+					Key:   &key,
+					Value: &svcName,
+				},
+				{
+					Key:   &key,
+					Value: &envName,
+				},
+			}
+
+			logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
+
+			So(string(output.Bytes()), ShouldContainSubstring, "SERVICE_NAME=test-service")
+			So(string(output.Bytes()), ShouldContainSubstring, "ENVIRONMENT_NAME=dev")
+		})
+
+		Convey("leaves environment and service undefined if no labels are set", func() {
 			taskInfo.Container.Docker.Parameters = []*mesos.Parameter{}
 
 			logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
 
-			So(string(output.Bytes()), ShouldContainSubstring, "SERVICE_NAME=undefined-servicename")
-			So(string(output.Bytes()), ShouldContainSubstring, "ENVIRONMENT_NAME=")
+			So(string(output.Bytes()), ShouldNotContainSubstring, "SERVICE_NAME=")
+			So(string(output.Bytes()), ShouldNotContainSubstring, "ENVIRONMENT_NAME=")
 		})
+
+		Convey("leaves version unset if it can't be parsed", func() {
+			image := "test-service"
+			taskInfo.Container.Docker.Image = &image
+			logTaskEnv(taskInfo, container.LabelsForTask(taskInfo))
+
+			So(string(output.Bytes()), ShouldNotContainSubstring, "SERVICE_VERSION=")
+		})
+
 	})
 }
 
@@ -261,11 +291,11 @@ func Test_watchContainer(t *testing.T) {
 
 		client.ListContainersContainers = []docker.APIContainers{
 			{
-				ID: "deadbeef0010",
+				ID:    "deadbeef0010",
 				State: "exited",
 			},
 			{
-				ID: "running00010",
+				ID:    "running00010",
 				State: "running",
 			},
 		}
@@ -336,13 +366,13 @@ func Test_SetProcessName(t *testing.T) {
 		originalLen := len(os.Args[0])
 
 		Convey("bounds the name length to existing length", func() {
-			SetProcessName(strings.Repeat("x", originalLen + 10))
+			SetProcessName(strings.Repeat("x", originalLen+10))
 			So(len(os.Args[0]), ShouldEqual, originalLen)
 		})
 
 		Convey("modifies ARGV[0] correctly and pads name", func() {
 			SetProcessName("decameron")
-			So(os.Args[0], ShouldResemble, "decameron" + strings.Repeat(" ", originalLen - len("decameron")))
+			So(os.Args[0], ShouldResemble, "decameron"+strings.Repeat(" ", originalLen-len("decameron")))
 		})
 	})
 }


### PR DESCRIPTION
This will take what is passed by Mesos as Docker labels for `EnvironmentName` and `ServiceName` and also pass them into the Docker container as `SERVICE_NAME` and `ENVIRONMENT_NAME` so that the service can be made aware of where it is running and what it is called.

Also exposes the docker tag as `SERVICE_VERSION` inside the container.