### PR TITLE
Make Docker container name follow Mesos specs.

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -236,7 +236,7 @@ func getHostname(taskInfo *mesos.TaskInfo) string {
 }
 
 // Map Task Env to Docker Env
-func AppendTaskEnv(envVars [] string, taskInfo * mesos.TaskInfo) [] string {
+func AppendTaskEnv(envVars []string, taskInfo *mesos.TaskInfo) []string {
 	if taskInfo.Executor == nil || taskInfo.Executor.Command == nil ||
 		taskInfo.Executor.Command.Environment == nil ||
 		taskInfo.Executor.Command.Environment.Variables == nil {

--- a/container/container.go
+++ b/container/container.go
@@ -314,6 +314,8 @@ func LabelsForTask(taskInfo *mesos.TaskInfo) map[string]string {
 		labels[values[0]] = values[1]
 	}
 
+	labels["TaskId"] = *taskInfo.TaskId.Value
+
 	return labels
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -335,8 +335,6 @@ func LabelsForTask(taskInfo *mesos.TaskInfo) map[string]string {
 		labels[values[0]] = values[1]
 	}
 
-	labels["TaskId"] = *taskInfo.TaskId.Value
-
 	return labels
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
 	mesos "github.com/mesos/mesos-go/api/v0/mesosproto"
+	"github.com/pborman/uuid"
 )
 
 // Using a small period (50ms) to ensure a consistency latency response at the expense of burst capacity
@@ -406,7 +407,9 @@ func getResource(name string, taskInfo *mesos.TaskInfo) *mesos.Resource {
 const DockerNamePrefix = "mesos-"
 
 func GetContainerName(taskId *mesos.TaskID) string {
-	return DockerNamePrefix + *taskId.Value
+	// unique uuid based on the TaskId
+	containerUUID := uuid.NewSHA1(uuid.NIL, []byte(*taskId.Value))
+	return DockerNamePrefix + containerUUID.String()
 }
 
 func GetExitCode(client DockerClient, containerId string) (int, error) {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -293,7 +293,8 @@ func Test_ConfigGeneration(t *testing.T) {
 
 		Convey("populates the environment", func() {
 			So(len(opts.Config.Env), ShouldBeGreaterThan, 1)
-			So(opts.Config.Env[0], ShouldEqual, "SOMETHING=123=123")
+			So(opts.Config.Env[0], ShouldEqual, "TASK_HOST=beowulf.example.com")
+			So(opts.Config.Env[1], ShouldEqual, "SOMETHING=123=123")
 		})
 
 		Convey("maps ports into the environment", func() {
@@ -331,11 +332,6 @@ func Test_ConfigGeneration(t *testing.T) {
 		Convey("gets the labels", func() {
 			So(len(opts.Config.Labels), ShouldBeGreaterThanOrEqualTo, 1)
 			So(opts.Config.Labels["ANYTHING"], ShouldEqual, "123=123")
-		})
-
-		Convey("gets Mesos TaskId as label", func() {
-			So(len(opts.Config.Labels), ShouldBeGreaterThanOrEqualTo, 1)
-			So(opts.Config.Labels["TaskId"], ShouldEqual, taskId)
 		})
 
 		Convey("gets the cap-adds", func() {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -149,6 +149,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		// The whole structure is full of pointers, so we have to define
 		// a bunch of things so we can take their address.
 		taskId := "nginx-2392676-1479746266455-1-dev_singularity_sick_sing-DEFAULT"
+		uuidTaskId := "f317e960-8579-5258-95c8-96ccca14f317" // UUID based on ssh1(taskId)
 		image := "foo/foo:1.0.0"
 		cpus := "cpus"
 		cpusValue := float64(0.5)
@@ -274,7 +275,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		optsForced := ConfigForTask(taskInfo, true, true, []string{})
 
 		Convey("gets the name from the task ID", func() {
-			So(opts.Name, ShouldEqual, "mesos-"+taskId)
+			So(opts.Name, ShouldEqual, "mesos-"+uuidTaskId)
 		})
 
 		Convey("properly calculates the CPU limit", func() {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -333,6 +333,11 @@ func Test_ConfigGeneration(t *testing.T) {
 			So(opts.Config.Labels["ANYTHING"], ShouldEqual, "123=123")
 		})
 
+		Convey("gets Mesos TaskId as label", func() {
+			So(len(opts.Config.Labels), ShouldBeGreaterThanOrEqualTo, 1)
+			So(opts.Config.Labels["TaskId"], ShouldEqual, taskId)
+		})
+
 		Convey("gets the cap-adds", func() {
 			So(len(opts.HostConfig.CapAdd), ShouldEqual, 1)
 			So(opts.HostConfig.CapAdd[0], ShouldEqual, "NET_ADMIN")


### PR DESCRIPTION
On the recovery/reconciliation process, Mesos agents are not able to kill orphan containers because they think they were not launched by Mesos.

Mesos recovery code [here](https://github.com/apache/mesos/blob/master/src/slave/containerizer/docker.cpp#L152) and [here](https://github.com/apache/mesos/blob/master/src/slave/containerizer/docker.cpp#L1093) is skipping the containers.
The only option is to use the expected Mesos container name "mesos-"+ uuid

