### PR TITLE
Add task name to container name

### DIFF
--- a/container/container_test.go
+++ b/container/container_test.go
@@ -285,7 +285,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		optsForced := ConfigForTask(taskInfo, true, true, []string{})
 
 		Convey("gets the name from the task ID", func() {
-			So(opts.Name, ShouldEqual, "mesos-"+uuidTaskId)
+			So(opts.Name, ShouldEqual, dockerNamePrefix+taskId+dockerNameSeparator+uuidTaskId)
 		})
 
 		Convey("properly calculates the CPU limit", func() {


### PR DESCRIPTION
Follow-up on #29. This format seems to be accepted by Mesos for backwards compatibility.

We might have to revise this in the future, if they decide to change it again (I doubt it).