### PR TITLE
Support looking up fields not named "value"

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -12,7 +12,7 @@ import (
 
 const VaultURLScheme = "vault"
 
-// Client to replace vault paths by the secret valued stored in the Hashicorp Vault
+// Client to replace vault paths by the secret value stored in Hashicorp Vault.
 type EnvVault struct {
 	client VaultAPI
 }
@@ -40,7 +40,7 @@ func NewDefaultVault() EnvVault {
 }
 
 // DecryptAllEnv decrypts all env vars that contain a Vault path.  All values
-// staring with `vault://` are overridden by the secret valued stored in the
+// staring with `vault://` are overridden by the secret value stored in the
 // path. For instance:
 //    Input: ["db_url=url","db_pass=vault://secret/db_pass"]
 //   Output: ["db_url=url","db_pass=ACTUAL_SECRET_PASS"]

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -63,6 +63,12 @@ func Test_DecryptEnvs(t *testing.T) {
 			So(securedValue, ShouldEqual, "some_sub_value")
 		})
 
+		Convey("ReadSecretValue returns an error on a missing sub-key", func() {
+			securedValue, err := envVault.ReadSecretValue("vault://secure/validKeyWithSub?key=missing")
+			So(err.Error(), ShouldContainSubstring, "Value for path 'secure/validKeyWithSub' not found")
+			So(securedValue, ShouldEqual, "")
+		})
+
 		Convey("Process all environment vars with Vault path", func() {
 			envs := []string{"Key1=Value1", "Key2=Value2", "Key3=vault://secure/validKey"}
 			expected := []string{"Key1=Value1", "Key2=Value2", "Key3=secret_value"}


### PR DESCRIPTION
In the original implementation, all Vault secrets needed to contain a single field named `value`. This PR supports any field name by specifying a URL in the form:
```
vault://secret/somewhere/prod-database?key=username
# or
vault://secret/somewhere/prod-database?key=password
```
Which would fetch the Vault secret and extract the field named `username`. It no query param is specified, it reverts to the original behavior and looks up the field named `value`.

*Note*: A few changes here are just the result of `gofmt -s`