### PR TITLE
Drain services in Sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,28 +97,28 @@ in the Mesos task. These will then be present for the executor at the time that
 it runs. Note that these are separate from the environment variables used in
 the Docker container. Currently the settings available are:
 
-```
-    Setting              Default
-	------------------------------------------------------
-	KillTaskTimeout:     5
-	HttpTimeout:         2s
-	SidecarRetryCount:   5
-	SidecarRetryDelay:   3s
-	SidecarUrl:          http://localhost:7777/state.json
-	SidecarBackoff:      1m5s
-	SidecarPollInterval: 30s
-	SidecarMaxFails:     3
-	SeedSidecar:         false
-	DockerRepository:    https://index.docker.io/v1/
-	LogsSince:           3m
-	ForceCpuLimit:       false
-	ForceMemoryLimit:    false
-	Debug:               false
-	RelaySyslog          false
-	SyslogAddr           127.0.0.1:514
-	ContainerLogsStdout  false
-	SendDockerLabels     []
-```
+Setting                 | Default
+------------------------|----------------------------
+KillTaskTimeout         | 5 (seconds)
+HttpTimeout             | 2s
+SidecarRetryCount       | 5
+SidecarRetryDelay       | 3s
+SidecarUrl              | http://localhost:7777/state.json
+SidecarBackoff          | 1m
+SidecarPollInterval     | 30s
+SidecarMaxFails         | 3
+SidecarDrainingDuration | 10s
+SeedSidecar             | false
+DockerRepository        | https://index.docker.io/v1/
+LogsSince               | 3m
+ForceCpuLimit           | false
+ForceMemoryLimit        | false
+Debug                   | false
+MesosMasterPort         | 5050
+RelaySyslog             | false
+SyslogAddr              | 127.0.0.1:514
+ContainerLogsStdout     | false
+SendDockerLabels        | []
 
 All of the environment variables are of the form `EXECUTOR_SIDECAR_RETRY_DELAY`
 where all of the CamelCased words are split apart, and each setting is prefixed
@@ -156,6 +156,11 @@ with `EXECUTOR_`.
    many _affirmed_ unhealthy checks we need to receive, each spaced apart by
    `SidecarPollInterval`.
 
+ * **SidecarDrainingDuration**: How much time to wait before killing the container
+   after instructing Sidecar to set the current service's status to `DRAINING`.
+   Setting this to `0` will prevent the executor from telling Sidecar to trigger
+   the `DRAINING` state and it will kill the container as soon as possible.
+
  * **SeedSidecar**: Should we query the Mesos master for the list of workers
    and then provide those in the `SIDECAR_SEEDS` environment variables?
 
@@ -176,6 +181,8 @@ with `EXECUTOR_`.
    cgroups (via Docker)?
 
  * **Debug**: Should we turn on debug logging (verbose!) for this executor?
+
+ * **MesosMasterPort**: The port on which the Mesos Master node listens on.
 
  * **RelaySyslog**: Should we relay container logs to syslog? This is a bare UDP
    implementation suitable for loggers that don't care about syslog protocol.

--- a/callbacks.go
+++ b/callbacks.go
@@ -154,10 +154,8 @@ func (exec *sidecarExecutor) KillTask(driver executor.ExecutorDriver, taskID *me
 	time.Sleep(exec.statusSleepTime)
 
 	log.Info("Executor believes container has exited, stopping Mesos driver")
-	_, err = exec.driver.Stop()
-	if err != nil {
-		log.Errorf("Error stopping driver: %s", err)
-	}
+
+	exec.stopDriver()
 }
 
 func (exec *sidecarExecutor) FrameworkMessage(driver executor.ExecutorDriver, msg string) {

--- a/callbacks.go
+++ b/callbacks.go
@@ -151,7 +151,7 @@ func (exec *sidecarExecutor) KillTask(driver executor.ExecutorDriver, taskID *me
 	exec.sendStatus(status, taskID)
 
 	// We have to give the driver time to send the message
-	time.Sleep(StatusSleepTime)
+	time.Sleep(exec.statusSleepTime)
 
 	log.Info("Executor believes container has exited, stopping Mesos driver")
 	_, err = exec.driver.Stop()

--- a/callbacks.go
+++ b/callbacks.go
@@ -102,7 +102,7 @@ func (exec *sidecarExecutor) LaunchTask(driver executor.ExecutorDriver, taskInfo
 	SetProcessName("sidecar-executor " + cntnr.ID[:12] + " (" + *taskInfo.Container.Docker.Image + ")")
 
 	exec.watchLooper =
-		director.NewImmediateTimedLooper(director.FOREVER, config.SidecarPollInterval, make(chan error))
+		director.NewImmediateTimedLooper(director.FOREVER, exec.config.SidecarPollInterval, make(chan error))
 
 	// We have to do this in a different goroutine or the scheduler
 	// can't send us any further updates.
@@ -128,7 +128,7 @@ func (exec *sidecarExecutor) KillTask(driver executor.ExecutorDriver, taskID *me
 
 	containerName := container.GetContainerName(taskID)
 
-	err := container.StopContainer(exec.client, containerName, config.KillTaskTimeout)
+	err := container.StopContainer(exec.client, containerName, exec.config.KillTaskTimeout)
 	if err != nil {
 		log.Errorf("Error stopping container %s! %s", containerName, err.Error())
 	}

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -1,10 +1,68 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
-	. "github.com/smartystreets/goconvey/convey"
+	"time"
+
+	"github.com/Nitro/sidecar-executor/container"
+	"github.com/Nitro/sidecar/service"
 	"github.com/fsouza/go-dockerclient"
+	mesos "github.com/mesos/mesos-go/api/v0/mesosproto"
+	director "github.com/relistan/go-director"
+	. "github.com/smartystreets/goconvey/convey"
 )
+
+type dummyMesosDriver struct {
+	isStopped      bool
+	receivedUpdate *mesos.TaskStatus
+}
+
+func (d *dummyMesosDriver) Running() bool              { return !d.isStopped }
+func (*dummyMesosDriver) Start() (mesos.Status, error) { return 0, nil }
+func (d *dummyMesosDriver) Stop() (mesos.Status, error) {
+	d.isStopped = true
+	return 0, nil
+}
+func (*dummyMesosDriver) Abort() (mesos.Status, error) { return 0, nil }
+func (*dummyMesosDriver) Join() (mesos.Status, error)  { return 0, nil }
+func (*dummyMesosDriver) Run() (mesos.Status, error)   { return 0, nil }
+func (d *dummyMesosDriver) SendStatusUpdate(taskStatus *mesos.TaskStatus) (mesos.Status, error) {
+	d.receivedUpdate = taskStatus
+	return 0, nil
+}
+func (*dummyMesosDriver) SendFrameworkMessage(string) (mesos.Status, error) { return 0, nil }
+
+type mockVault struct {
+	failDecrypt bool
+}
+
+func (v *mockVault) DecryptAllEnv(envs []string) ([]string, error) {
+	if v.failDecrypt {
+		return nil, errors.New("some error")
+	}
+
+	var decryptedEnv []string
+	for _, env := range envs {
+		keyValue := strings.SplitN(env, "=", 2)
+		envName := keyValue[0]
+		envValue := keyValue[1]
+
+		if envValue == "encrypted" {
+			decryptedEnv = append(decryptedEnv, envName+"=decrypted")
+		} else {
+			decryptedEnv = append(decryptedEnv, env)
+		}
+	}
+
+	return decryptedEnv, nil
+}
 
 func Test_shouldCheckSidecar(t *testing.T) {
 	Convey("When checking if Sidecar is enabled", t, func() {
@@ -18,15 +76,395 @@ func Test_shouldCheckSidecar(t *testing.T) {
 		})
 
 		Convey("shouldCheckSidecar should be true when SidecarDiscover=true", func() {
-			containerOptions.Config.Labels = map[string]string{"SidecarDiscover" : "true"}
+			containerOptions.Config.Labels = map[string]string{"SidecarDiscover": "true"}
 
 			So(shouldCheckSidecar(containerOptions), ShouldBeTrue)
 		})
 
 		Convey("shouldCheckSidecar should be false when SidecarDiscover=false", func() {
-			containerOptions.Config.Labels = map[string]string{"SidecarDiscover" : "false"}
+			containerOptions.Config.Labels = map[string]string{"SidecarDiscover": "false"}
 
 			So(shouldCheckSidecar(containerOptions), ShouldBeFalse)
+		})
+	})
+}
+
+func containerLabelsToDockerParameters(labels map[string]string) []*mesos.Parameter {
+	var parameters []*mesos.Parameter
+	key := "label"
+	for labelKey, labelValue := range labels {
+		value := labelKey + "=" + labelValue
+		parameters = append(parameters,
+			&mesos.Parameter{Key: &key, Value: &value},
+		)
+	}
+
+	return parameters
+}
+
+func Test_ExecutorCallbacks(t *testing.T) {
+	Convey("sidecarExecutor should", t, func(c C) {
+		dummyServiceName := "foobar"
+		dummyTaskName := dummyServiceName + "_task"
+		dummyTaskIdValue := "task_42"
+		dummyTaskId := mesos.TaskID{Value: &dummyTaskIdValue}
+		dummyCommand := "sudo_make_me_a_sandwich"
+		dummyContainerId := "123456654321"
+		dummyDockerImageTag := "666"
+		dummyDockerImageId := dummyServiceName + ":" + dummyDockerImageTag
+		dummyEnvironmentName := "mordor"
+		dummyTaskHost := "brainiac"
+		dummyMesosWorkerHost := "jotunheim"
+		dummyContainerPort := uint32(80)
+		dummyHostPort := uint32(8080)
+		// computed via `container.GetContainerName(&dummyTaskId)`
+		expectedContainerId := "mesos-5cf434e4-0723-522d-aea0-1a344f913c23"
+
+		// Required by sidecarLookup()
+		err := os.Setenv("TASK_HOST", dummyTaskHost)
+		So(err, ShouldBeNil)
+		defer os.Unsetenv("TASK_HOST")
+
+		mux := http.NewServeMux()
+		fakeServer := httptest.NewServer(mux)
+		Reset(func() {
+			fakeServer.Close()
+		})
+
+		// Sidecar services handler
+		sidecarStateCalls := 0
+		Reset(func() {
+			sidecarStateCalls = 0
+		})
+		mux.HandleFunc("/state.json",
+			func(w http.ResponseWriter, r *http.Request) {
+				sidecarStateCalls++
+
+				services := SidecarServices{
+					Servers: map[string]SidecarServer{
+						dummyTaskHost: {
+							Services: map[string]service.Service{
+								expectedContainerId[:12]: {},
+							},
+						},
+					},
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(services)
+				c.So(err, ShouldBeNil)
+			},
+		)
+		// Sidecar drain handler
+		sidecarDrainCalls := 0
+		sidecarDrainFailOnce := false
+		Reset(func() {
+			sidecarDrainCalls = 0
+			sidecarDrainFailOnce = false
+		})
+		mux.HandleFunc(
+			fmt.Sprintf("/api/services/%s/drain", dummyContainerId),
+			func(w http.ResponseWriter, r *http.Request) {
+				c.So(r.URL.Path, ShouldEqual, fmt.Sprintf("/api/services/%s/drain", dummyContainerId))
+
+				sidecarDrainCalls++
+
+				if sidecarDrainFailOnce && sidecarDrainCalls == 1 {
+					http.Error(w, "Kaboom!", 500)
+					return
+				}
+
+				w.WriteHeader(202)
+			},
+		)
+		// Mesos master handler
+		mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"master_hostname":"`+fakeServer.Listener.Addr().String()+`"}`)
+		})
+		// Mesos slaves handler
+		mux.HandleFunc("/slaves", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"slaves":[{"hostname":"`+dummyMesosWorkerHost+`"}]}`)
+		})
+
+		dummyDockerClient := container.MockDockerClient{
+			Container: &docker.Container{
+				State: docker.State{Status: "exited"},
+			},
+			Images: []docker.APIImages{
+				{
+					ID: dummyDockerImageId,
+				},
+			},
+			ListContainersContainers: []docker.APIContainers{
+				{ID: container.GetContainerName(&dummyTaskId)},
+			},
+		}
+
+		dummyMesosDriver := dummyMesosDriver{}
+
+		dummyVault := mockVault{}
+
+		exec := sidecarExecutor{
+			dockerAuth: &docker.AuthConfiguration{},
+			client:     &dummyDockerClient,
+			driver:     &dummyMesosDriver,
+			fetcher:    http.DefaultClient,
+			config: Config{
+				SidecarUrl:              fakeServer.URL + "/state.json",
+				SidecarDrainingDuration: 1 * time.Millisecond,
+				SidecarPollInterval:     1 * time.Millisecond,
+			},
+			containerID: dummyContainerId,
+			vault:       &dummyVault,
+		}
+
+		dummyContainerLabels := map[string]string{
+			"ServiceName":     dummyServiceName,
+			"EnvironmentName": dummyEnvironmentName,
+			// We don't want to check Sidecar in most tests
+			"SidecarDiscover": "false",
+		}
+
+		var dockerNetworkMode mesos.ContainerInfo_DockerInfo_Network
+		taskId := "TASK_ID"
+		taskHost := "TASK_HOST"
+		taskInfo := mesos.TaskInfo{
+			Name:   &dummyTaskName,
+			TaskId: &dummyTaskId,
+			Command: &mesos.CommandInfo{
+				Value: &dummyCommand,
+			},
+			Executor: &mesos.ExecutorInfo{
+				Command: &mesos.CommandInfo{
+					Environment: &mesos.Environment{
+						Variables: []*mesos.Environment_Variable{
+							{Name: &taskId, Value: &dummyTaskIdValue},
+							{Name: &taskHost, Value: &dummyTaskHost},
+						},
+					},
+				},
+			},
+			Container: &mesos.ContainerInfo{
+				Docker: &mesos.ContainerInfo_DockerInfo{
+					Image:   &dummyDockerImageId,
+					Network: &dockerNetworkMode,
+					PortMappings: []*mesos.ContainerInfo_DockerInfo_PortMapping{
+						{HostPort: &dummyHostPort, ContainerPort: &dummyContainerPort},
+					},
+					Parameters: containerLabelsToDockerParameters(dummyContainerLabels),
+				},
+			},
+		}
+
+		Convey("LaunchTask()", func() {
+			Convey("launches a task", func() {
+				Convey("and sends an update to Mesos", func() {
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(dummyMesosDriver.receivedUpdate, ShouldNotBeNil)
+					So(dummyMesosDriver.receivedUpdate.TaskId, ShouldNotBeNil)
+					So(dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldNotBeNil)
+					So(*dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldEqual, dummyTaskIdValue)
+					So(dummyMesosDriver.receivedUpdate.State, ShouldNotBeNil)
+					So(*dummyMesosDriver.receivedUpdate.State, ShouldEqual, *mesos.TaskState_TASK_RUNNING.Enum())
+				})
+
+				Convey("and seeds sidecar", func() {
+					exec.config.SeedSidecar = true
+					err := os.Setenv("MESOS_AGENT_ENDPOINT", fakeServer.Listener.Addr().String())
+					So(err, ShouldBeNil)
+					defer os.Unsetenv("MESOS_AGENT_ENDPOINT")
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(exec.containerConfig.Config.Env, ShouldContain, "SIDECAR_SEEDS="+dummyMesosWorkerHost)
+				})
+
+				Convey("and initialises the container config", func() {
+					envKey := "env"
+					extraEnvVal := "TEST_VAR=dummy_value"
+					taskInfo.Container.Docker.Parameters = append(
+						taskInfo.Container.Docker.Parameters,
+						&mesos.Parameter{Key: &envKey, Value: &extraEnvVal},
+					)
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					Convey("and pulls image", func() {
+						So(dummyDockerClient.ValidOptions, ShouldBeTrue)
+					})
+
+					Convey("and sets the container config on the executor", func() {
+						So(exec.containerConfig, ShouldNotBeNil)
+						So(exec.containerConfig.Name, ShouldEqual, expectedContainerId)
+					})
+
+					Convey("and sets the container ID on the executor", func() {
+						So(exec.containerID, ShouldEqual, expectedContainerId)
+					})
+
+					Convey("and appends the task env vars", func() {
+						So(exec.containerConfig.Config.Env, ShouldContain, "SERVICE_VERSION="+dummyDockerImageTag)
+						So(exec.containerConfig.Config.Env, ShouldContain, taskId+"="+dummyTaskIdValue)
+						So(exec.containerConfig.Config.Env, ShouldContain, taskHost+"="+dummyTaskHost)
+					})
+
+					Convey("and sets the MESOS_PORT_* env vars", func() {
+						So(exec.containerConfig.Config.Env, ShouldContain, fmt.Sprintf("MESOS_PORT_%d=%d", dummyContainerPort, dummyHostPort))
+					})
+
+					Convey("and sets the MESOS_HOSTNAME env var", func() {
+						So(exec.containerConfig.Config.Env, ShouldContain, "MESOS_HOSTNAME="+dummyTaskHost)
+					})
+
+					Convey("and sets any extra env vars", func() {
+						So(exec.containerConfig.Config.Env, ShouldContain, extraEnvVal)
+					})
+
+					Convey("and starts the container", func() {
+						So(dummyDockerClient.ContainerStarted, ShouldBeTrue)
+					})
+
+					Convey("and sets the process name", func() {
+						So(os.Args[0], ShouldStartWith, "sidecar-executor")
+						So(os.Args[0], ShouldContainSubstring, dummyDockerImageId)
+					})
+
+					Convey("and initialises the watch looper", func() {
+						So(exec.watchLooper, ShouldNotBeNil)
+					})
+				})
+
+				Convey("and reuses existing docker image", func() {
+					dummyDockerClient.Images[0].RepoTags = []string{dummyDockerImageId}
+					falseValue := false
+					taskInfo.Container.Docker.ForcePullImage = &falseValue
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(dummyDockerClient.ValidOptions, ShouldBeFalse)
+				})
+
+				Convey("and force pulls docker images even if they exist, if configured to do so", func() {
+					dummyDockerClient.Images[0].RepoTags = []string{dummyDockerImageId}
+					trueValue := true
+					taskInfo.Container.Docker.ForcePullImage = &trueValue
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(dummyDockerClient.ValidOptions, ShouldBeTrue)
+				})
+
+				Convey("and decrypts vault secrets", func() {
+					envKey := "env"
+					encryptedVal := "SUPER_SECRET_KEY=encrypted"
+					decryptedVal := "SUPER_SECRET_KEY=decrypted"
+					taskInfo.Container.Docker.Parameters = append(
+						taskInfo.Container.Docker.Parameters,
+						&mesos.Parameter{Key: &envKey, Value: &encryptedVal},
+					)
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(exec.containerConfig.Config.Env, ShouldContain, decryptedVal)
+				})
+
+				Convey("and fails to launch a task when it can't decrypt vault secrets", func() {
+					dummyVault.failDecrypt = true
+
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(dummyMesosDriver.isStopped, ShouldBeTrue)
+
+					Convey("and sends an update to Mesos", func() {
+						So(dummyMesosDriver.receivedUpdate, ShouldNotBeNil)
+						So(dummyMesosDriver.receivedUpdate.TaskId, ShouldNotBeNil)
+						So(dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldNotBeNil)
+						So(*dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldEqual, dummyTaskIdValue)
+						So(dummyMesosDriver.receivedUpdate.State, ShouldNotBeNil)
+						So(*dummyMesosDriver.receivedUpdate.State, ShouldEqual, *mesos.TaskState_TASK_FAILED.Enum())
+					})
+				})
+
+				Convey("and checks the container health via Sidecar", func() {
+					dummyContainerLabels["SidecarDiscover"] = "true"
+					taskInfo.Container.Docker.Parameters = containerLabelsToDockerParameters(dummyContainerLabels)
+					exec.LaunchTask(exec.driver, &taskInfo)
+					exec.watchLooper.Quit()
+					err := exec.watchLooper.Wait()
+					So(err, ShouldBeNil)
+					So(sidecarStateCalls, ShouldEqual, 1)
+				})
+
+				// TODO: test exec.handleContainerLogs
+			})
+
+			Convey("fails to launch a task", func() {
+				Convey("when it fails to pull an image", func() {
+					dummyDockerClient.PullImageShouldError = true
+					exec.LaunchTask(exec.driver, &taskInfo)
+
+					So(dummyMesosDriver.isStopped, ShouldBeTrue)
+
+					Convey("and sends an update to Mesos", func() {
+						So(dummyMesosDriver.receivedUpdate, ShouldNotBeNil)
+						So(dummyMesosDriver.receivedUpdate.TaskId, ShouldNotBeNil)
+						So(dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldNotBeNil)
+						So(*dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldEqual, dummyTaskIdValue)
+						So(dummyMesosDriver.receivedUpdate.State, ShouldNotBeNil)
+						So(*dummyMesosDriver.receivedUpdate.State, ShouldEqual, *mesos.TaskState_TASK_FAILED.Enum())
+					})
+				})
+			})
+		})
+
+		Convey("KillTask()", func() {
+			dummyContainerLabels["SidecarDiscover"] = "true"
+			exec.containerConfig = &docker.CreateContainerOptions{
+				Config: &docker.Config{
+					Labels: dummyContainerLabels,
+				},
+			}
+			exec.watchLooper = director.NewFreeLooper(1, make(chan error))
+
+			Convey("drains the service", func() {
+				exec.KillTask(exec.driver, &dummyTaskId)
+				So(sidecarDrainCalls, ShouldEqual, 1)
+
+				Convey("and sends an update to Mesos", func() {
+					So(dummyMesosDriver.receivedUpdate, ShouldNotBeNil)
+					So(dummyMesosDriver.receivedUpdate.TaskId, ShouldNotBeNil)
+					So(dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldNotBeNil)
+					So(*dummyMesosDriver.receivedUpdate.TaskId.Value, ShouldEqual, dummyTaskIdValue)
+					So(dummyMesosDriver.receivedUpdate.State, ShouldNotBeNil)
+					So(*dummyMesosDriver.receivedUpdate.State, ShouldEqual, *mesos.TaskState_TASK_FINISHED.Enum())
+				})
+
+				Convey("and stops the Mesos driver", func() {
+					So(dummyMesosDriver.isStopped, ShouldBeTrue)
+				})
+			})
+
+			Convey("tries multiple times to drain the service", func() {
+				exec.config.SidecarRetryCount = 1
+				sidecarDrainFailOnce = true
+				exec.KillTask(exec.driver, &dummyTaskId)
+				So(sidecarDrainCalls, ShouldEqual, 2)
+			})
+
+			Convey("doesn't drain the the service when it has the label SidecarDiscover=false", func() {
+				dummyContainerLabels["SidecarDiscover"] = "false"
+				exec.KillTask(exec.driver, &dummyTaskId)
+				So(sidecarDrainCalls, ShouldEqual, 0)
+			})
+
+			Convey("doesn't drain the service when the SidecarDrainingDuration config parameter is 0", func() {
+				exec.config.SidecarDrainingDuration = 0
+				exec.KillTask(exec.driver, &dummyTaskId)
+				So(sidecarDrainCalls, ShouldEqual, 0)
+			})
 		})
 	})
 }

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -38,7 +38,7 @@ func Test_PullImage(t *testing.T) {
 		Convey("passes the right params", func() {
 			err := PullImage(dockerClient, taskInfo, &docker.AuthConfiguration{})
 
-			So(dockerClient.validOptions, ShouldBeTrue)
+			So(dockerClient.ValidOptions, ShouldBeTrue)
 			So(err, ShouldBeNil)
 		})
 

--- a/container/mock_docker_client.go
+++ b/container/mock_docker_client.go
@@ -7,7 +7,7 @@ import (
 )
 
 type MockDockerClient struct {
-	validOptions                bool
+	ValidOptions                bool
 	PullImageShouldError        bool
 	Images                      []docker.APIImages
 	ListImagesShouldError       bool
@@ -21,6 +21,7 @@ type MockDockerClient struct {
 	LogErrorString              string
 	ListContainersShouldError   bool
 	ListContainersContainers    []docker.APIContainers
+	ContainerStarted            bool
 }
 
 func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
@@ -29,7 +30,7 @@ func (m *MockDockerClient) PullImage(opts docker.PullImageOptions, auth docker.A
 	}
 
 	if len(opts.Repository) > 5 && (docker.AuthConfiguration{}) == auth {
-		m.validOptions = true
+		m.ValidOptions = true
 	}
 
 	return nil
@@ -82,10 +83,11 @@ func (m *MockDockerClient) Logs(opts docker.LogsOptions) error {
 }
 
 func (m *MockDockerClient) CreateContainer(opts docker.CreateContainerOptions) (*docker.Container, error) {
-	return nil, nil
+	return &docker.Container{ID: opts.Name}, nil
 }
 
 func (m *MockDockerClient) StartContainer(id string, hostConfig *docker.HostConfig) error {
+	m.ContainerStarted = true
 	return nil
 }
 

--- a/executor_utils.go
+++ b/executor_utils.go
@@ -31,7 +31,7 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 	if err != nil {
 		log.Errorf("Error! %s", err)
 		// Something went wrong, we better take this thing out!
-		err := container.StopContainer(exec.client, containerName, config.KillTaskTimeout)
+		err := container.StopContainer(exec.client, containerName, exec.config.KillTaskTimeout)
 		if err != nil {
 			log.Errorf("Error stopping container %s! %s", containerName, err)
 		}
@@ -50,7 +50,7 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 // capture some failure information in the Mesos logs. Then tooling can fetch
 // crash info from the Mesos API.
 func (exec *sidecarExecutor) copyLogs(containerId string) {
-	startTimeEpoch := time.Now().UTC().Add(0 - config.LogsSince).Unix()
+	startTimeEpoch := time.Now().UTC().Add(0 - exec.config.LogsSince).Unix()
 
 	container.GetLogs(
 		exec.client, containerId, startTimeEpoch, os.Stdout, os.Stderr,

--- a/executor_utils.go
+++ b/executor_utils.go
@@ -112,7 +112,11 @@ func (exec *sidecarExecutor) getMasterHostname() (string, error) {
 
 // getWorkerHostnames returns a slice of all the current worker hostnames
 func (exec *sidecarExecutor) getWorkerHostnames(masterHostname string) ([]string, error) {
-	masterEndpoint := "http://" + masterHostname + ":5050/slaves"
+	masterAddr := masterHostname
+	if exec.config.MesosMasterPort != "" {
+		masterAddr += ":" + exec.config.MesosMasterPort
+	}
+	masterEndpoint := "http://" + masterAddr + "/slaves"
 
 	type workersStruct struct {
 		Hostname string `json:"hostname"`

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -19,7 +19,10 @@ func Test_relayLogs(t *testing.T) {
 			LogOutputString: "this is some stdout text\n",
 			LogErrorString:  "this is some stderr text\n",
 		}
-		exec := newSidecarExecutor(dockerClient, &docker.AuthConfiguration{})
+
+		config, err := initConfig()
+		So(err, ShouldBeNil)
+		exec := newSidecarExecutor(dockerClient, &docker.AuthConfiguration{}, config)
 		exec.config.SendDockerLabels = []string{"Environment", "ServiceName"}
 
 		// Stub out the fetcher
@@ -65,7 +68,9 @@ func Test_handleOneStream(t *testing.T) {
 	Convey("handleOneStream()", t, func() {
 		fetcher := &mockFetcher{}
 		client := &container.MockDockerClient{}
-		exec := newSidecarExecutor(client, &docker.AuthConfiguration{})
+		config, err := initConfig()
+		So(err, ShouldBeNil)
+		exec := newSidecarExecutor(client, &docker.AuthConfiguration{}, config)
 		exec.fetcher = fetcher
 
 		quitChan := make(chan struct{})

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -43,20 +44,21 @@ var (
 )
 
 type Config struct {
-	KillTaskTimeout     uint          `envconfig:"KILL_TASK_TIMEOUT" default:"5"` // Seconds
-	HttpTimeout         time.Duration `envconfig:"HTTP_TIMEOUT" default:"2s"`
-	SidecarRetryCount   int           `envconfig:"SIDECAR_RETRY_COUNT" default:"5"`
-	SidecarRetryDelay   time.Duration `envconfig:"SIDECAR_RETRY_DELAY" default:"3s"`
-	SidecarUrl          string        `envconfig:"SIDECAR_URL" default:"http://localhost:7777/state.json"`
-	SidecarBackoff      time.Duration `envconfig:"SIDECAR_BACKOFF" default:"1m"`
-	SidecarPollInterval time.Duration `envconfig:"SIDECAR_POLL_INTERVAL" default:"30s"`
-	SidecarMaxFails     int           `envconfig:"SIDECAR_MAX_FAILS" default:"3"`
-	SeedSidecar         bool          `envconfig:"SEED_SIDECAR" default:"false"`
-	DockerRepository    string        `envconfig:"DOCKER_REPOSITORY" default:"https://index.docker.io/v1/"`
-	LogsSince           time.Duration `envconfig:"LOGS_SINCE" default:"3m"`
-	ForceCpuLimit       bool          `envconfig:"FORCE_CPU_LIMIT" default:"false"`
-	ForceMemoryLimit    bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
-	Debug               bool          `envconfig:"DEBUG" default:"false"`
+	KillTaskTimeout         uint          `envconfig:"KILL_TASK_TIMEOUT" default:"5"` // Seconds
+	HttpTimeout             time.Duration `envconfig:"HTTP_TIMEOUT" default:"2s"`
+	SidecarRetryCount       int           `envconfig:"SIDECAR_RETRY_COUNT" default:"5"`
+	SidecarRetryDelay       time.Duration `envconfig:"SIDECAR_RETRY_DELAY" default:"3s"`
+	SidecarUrl              string        `envconfig:"SIDECAR_URL" default:"http://localhost:7777/state.json"`
+	SidecarBackoff          time.Duration `envconfig:"SIDECAR_BACKOFF" default:"1m"`
+	SidecarPollInterval     time.Duration `envconfig:"SIDECAR_POLL_INTERVAL" default:"30s"`
+	SidecarMaxFails         int           `envconfig:"SIDECAR_MAX_FAILS" default:"3"`
+	SidecarDrainingDuration time.Duration `envconfig:"SIDECAR_DRAINING_DURATION" default:"10s"`
+	SeedSidecar             bool          `envconfig:"SEED_SIDECAR" default:"false"`
+	DockerRepository        string        `envconfig:"DOCKER_REPOSITORY" default:"https://index.docker.io/v1/"`
+	LogsSince               time.Duration `envconfig:"LOGS_SINCE" default:"3m"`
+	ForceCpuLimit           bool          `envconfig:"FORCE_CPU_LIMIT" default:"false"`
+	ForceMemoryLimit        bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
+	Debug                   bool          `envconfig:"DEBUG" default:"false"`
 
 	// Mesos options
 	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`
@@ -79,6 +81,9 @@ type sidecarExecutor struct {
 	vault           vault.EnvVault
 	config          Config
 	statusSleepTime time.Duration
+	// Populated during LaunchTask
+	containerConfig *docker.CreateContainerOptions
+	containerID     string
 }
 
 type SidecarServices struct {
@@ -89,6 +94,7 @@ type SidecarServices struct {
 
 type SidecarFetcher interface {
 	Get(url string) (resp *http.Response, err error)
+	Post(url string, contentType string, body io.Reader) (resp *http.Response, err error)
 }
 
 func newSidecarExecutor(client container.DockerClient, auth *docker.AuthConfiguration) *sidecarExecutor {
@@ -104,25 +110,26 @@ func newSidecarExecutor(client container.DockerClient, auth *docker.AuthConfigur
 
 func logConfig() {
 	log.Infof("Executor Config -----------------------")
-	log.Infof(" * KillTaskTimeout:     %d", config.KillTaskTimeout)
-	log.Infof(" * HttpTimeout:         %s", config.HttpTimeout.String())
-	log.Infof(" * SidecarRetryCount:   %d", config.SidecarRetryCount)
-	log.Infof(" * SidecarRetryDelay:   %s", config.SidecarRetryDelay.String())
-	log.Infof(" * SidecarUrl:          %s", config.SidecarUrl)
-	log.Infof(" * SidecarBackoff:      %s", config.SidecarBackoff.String())
-	log.Infof(" * SidecarPollInterval: %s", config.SidecarPollInterval.String())
-	log.Infof(" * SidecarMaxFails:     %d", config.SidecarMaxFails)
-	log.Infof(" * SeedSidecar:         %t", config.SeedSidecar)
-	log.Infof(" * DockerRepository:    %s", config.DockerRepository)
-	log.Infof(" * LogsSince:           %s", config.LogsSince.String())
-	log.Infof(" * ForceCpuLimit:       %t", config.ForceCpuLimit)
-	log.Infof(" * ForceMemoryLimit:    %t", config.ForceMemoryLimit)
-	log.Infof(" * MesosMasterPort:     %s", config.MesosMasterPort)
-	log.Infof(" * RelaySyslog:         %t", config.RelaySyslog)
-	log.Infof(" * SyslogAddr:          %s", config.SyslogAddr)
-	log.Infof(" * ContainerLogsStdout: %t", config.ContainerLogsStdout)
-	log.Infof(" * SendDockerLabels:    %v", config.SendDockerLabels)
-	log.Infof(" * Debug:               %t", config.Debug)
+	log.Infof(" * KillTaskTimeout:         %d", config.KillTaskTimeout)
+	log.Infof(" * HttpTimeout:             %s", config.HttpTimeout.String())
+	log.Infof(" * SidecarRetryCount:       %d", config.SidecarRetryCount)
+	log.Infof(" * SidecarRetryDelay:       %s", config.SidecarRetryDelay.String())
+	log.Infof(" * SidecarUrl:              %s", config.SidecarUrl)
+	log.Infof(" * SidecarBackoff:          %s", config.SidecarBackoff.String())
+	log.Infof(" * SidecarPollInterval:     %s", config.SidecarPollInterval.String())
+	log.Infof(" * SidecarMaxFails:         %d", config.SidecarMaxFails)
+	log.Infof(" * SidecarDrainingDuration: %s", config.SidecarDrainingDuration)
+	log.Infof(" * SeedSidecar:             %t", config.SeedSidecar)
+	log.Infof(" * DockerRepository:        %s", config.DockerRepository)
+	log.Infof(" * LogsSince:               %s", config.LogsSince.String())
+	log.Infof(" * ForceCpuLimit:           %t", config.ForceCpuLimit)
+	log.Infof(" * ForceMemoryLimit:        %t", config.ForceMemoryLimit)
+	log.Infof(" * MesosMasterPort:         %s", config.MesosMasterPort)
+	log.Infof(" * RelaySyslog:             %t", config.RelaySyslog)
+	log.Infof(" * SyslogAddr:              %s", config.SyslogAddr)
+	log.Infof(" * ContainerLogsStdout:     %t", config.ContainerLogsStdout)
+	log.Infof(" * SendDockerLabels:        %v", config.SendDockerLabels)
+	log.Infof(" * Debug:                   %t", config.Debug)
 
 	log.Infof("Environment ---------------------------")
 	for _, setting := range os.Environ() {

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ type sidecarExecutor struct {
 	client          container.DockerClient
 	fetcher         SidecarFetcher
 	watchLooper     director.Looper
+	watcherDoneChan chan struct{}
 	logsQuitChan    chan struct{}
 	dockerAuth      *docker.AuthConfiguration
 	failCount       int
@@ -114,6 +115,7 @@ func newSidecarExecutor(client container.DockerClient, auth *docker.AuthConfigur
 	return &sidecarExecutor{
 		client:          client,
 		fetcher:         &http.Client{Timeout: config.HttpTimeout},
+		watcherDoneChan: make(chan struct{}),
 		dockerAuth:      auth,
 		vault:           vault.NewDefaultVault(),
 		config:          config,

--- a/main.go
+++ b/main.go
@@ -58,6 +58,9 @@ type Config struct {
 	ForceMemoryLimit    bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
 	Debug               bool          `envconfig:"DEBUG" default:"false"`
 
+	// Mesos options
+	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`
+
 	// Syslogging options
 	RelaySyslog         bool     `envconfig:"RELAY_SYSLOG" default:"false"`
 	SyslogAddr          string   `envconfig:"SYSLOG_ADDR" default:"127.0.0.1:514"`
@@ -114,6 +117,7 @@ func logConfig() {
 	log.Infof(" * LogsSince:           %s", config.LogsSince.String())
 	log.Infof(" * ForceCpuLimit:       %t", config.ForceCpuLimit)
 	log.Infof(" * ForceMemoryLimit:    %t", config.ForceMemoryLimit)
+	log.Infof(" * MesosMasterPort:     %s", config.MesosMasterPort)
 	log.Infof(" * RelaySyslog:         %t", config.RelaySyslog)
 	log.Infof(" * SyslogAddr:          %s", config.SyslogAddr)
 	log.Infof(" * ContainerLogsStdout: %t", config.ContainerLogsStdout)

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -58,6 +59,10 @@ func (m *mockFetcher) Get(url string) (*http.Response, error) {
 	} else {
 		return m.successRequest()
 	}
+}
+
+func (m *mockFetcher) Post(url string, contentType string, body io.Reader) (*http.Response, error) {
+	return nil, nil
 }
 
 func (m *mockFetcher) successRequest() (*http.Response, error) {


### PR DESCRIPTION
This contains the required changes to trigger the new `DRAINING` state [implemented](https://github.com/Nitro/sidecar/pull/47) in Sidecar. It also contains some small fixes and adds a bunch of tests.

In detail:
- 504fe84 - Stop trying to fetch state from Sidecar when successful: Unless I'm mistaking, the code was fetching the state from Sidecar `SidecarRetryCount` times in each iteration of the `watchLooper`, even if the Sidecar call would succeed. I believe I have fixed this.
- 827210c - Turn `StatusSleepTime` into a parameter of `sidecarExecutor`, so the code is easier to test.
- b6765e4 - Check if the Mesos driver is running before attempting to stop it: Trying to stop the Mesos driver when it's status is not `DRIVER_RUNNING` [causes it to return an error](https://github.com/Nitro/sidecar-executor/blob/79f079f6e342963c8dc595c7d4f1f3f582fa0749/vendor/github.com/mesos/mesos-go/api/v0/executor/executor.go#L573). This issue has surfaced after #43.
- 0709064 - Make Mesos Master port configurable: Enables more testing.
- c4734c2 - Drain services in Sidecar before stopping them: This contains the actual implementation for triggering the new `DRAINING` state in Sidecar.
    - I cached the `containerConfig` and the `containerID` on the `sidecarExecutor` object because I need to reuse them in `KillTask` and in `drainService`.
    - Also, I'm reusing the `SidecarUrl` which defaults to `http://localhost:7777/state.json` for figuring out the URL to which I need to send the drain service POST request.
    - cb06719 - Stop waiting for the service to drain if the container exits prematurely
- a9bec29 - Cleanup global config: Having `config` as a global object makes testing very difficult. I have refactored the code to always read the config from `sidecarExecutor`.
- 2fa11b9 - Add loads of tests for the callbacks.
- f4a4777 - Update Readme to document SidecarDrainingDuration and MesosMasterPort.