### PR TITLE
Attempt harder to only log errors as errors

### DIFF
--- a/log_relay.go
+++ b/log_relay.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"io"
+	"strings"
 
 	"github.com/Nitro/sidecar-executor/container"
 	"github.com/Nitro/sidecar-executor/loghooks"
@@ -79,7 +80,12 @@ func (exec *sidecarExecutor) handleOneStream(quitChan chan struct{}, name string
 		case "stdout":
 			logger.Info(text) // Send to syslog "info"
 		case "stderr":
-			logger.Error(text) // Send to syslog "error"
+			// Pretty basic attempt to scrape only errors from the logs
+			if strings.Contains(strings.ToLower(text), "error") {
+				logger.Error(text) // Send to syslog "error"
+			} else {
+				logger.Info(text) // Send to syslog "info"
+			}
 		default:
 			log.Errorf("handleOneStream(): Unknown stream type '%s'. Exiting log pump.", name)
 			return

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -108,5 +108,19 @@ func Test_handleOneStream(t *testing.T) {
 
 			So(captured.String(), ShouldContainSubstring, "Unknown stream type")
 		})
+
+		Convey("sends strings containing 'error' to stderr, everything else to stdout", func() {
+			dataWithError := []byte("ERROR: testing testing testing\n123\n456")
+			readerWithError := bytes.NewReader(dataWithError)
+
+			var captured bytes.Buffer // System log, NOT logger
+			log.SetOutput(&captured)
+
+			exec.handleOneStream(quitChan, "stderr", relay, readerWithError)
+
+			So(result.String(), ShouldContainSubstring, `level=error msg="ERROR:`)
+			So(result.String(), ShouldContainSubstring, `level=info msg=123`)
+			So(result.String(), ShouldContainSubstring, `level=info msg=456`)
+		})
 	})
 }


### PR DESCRIPTION
Anything where we scrape the logs is going to be a compromise and this attempts to push it more in the direction of only logging actual errors as errors. Of course, some applications will send errors to stderr and everything else to stdout as a proper application should do, but these days it seems to be increasingly rare that applications work like that.