### PR TITLE
Display the environment variables sorted to have them grouped

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -147,7 +148,9 @@ func logConfig(config Config) {
 	log.Infof(" * Debug:                   %t", config.Debug)
 
 	log.Infof("Environment ---------------------------")
-	for _, setting := range os.Environ() {
+	envVars := os.Environ()
+	sort.Strings(envVars)
+	for _, setting := range envVars {
 		if setting == "VAULT_TOKEN" {
 			continue
 		}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const VaultURLScheme = "vault"
+const (
+	VaultURLScheme  = "vault"
+	VaultDefaultKey = "value"
+)
 
 // Client to replace vault paths by the secret value stored in Hashicorp Vault.
 type EnvVault struct {
@@ -47,7 +50,7 @@ func NewDefaultVault() EnvVault {
 //
 //
 // By default, the key used to retrieve the contents of the Secret that Vault
-// returns is the string "value". If you have more than one entry stored in a
+// returns is the string `VaultDefaultKey`. If you have more than one entry stored in a
 // Secret and need to refer to them by name, you may append a query string
 // specifying the key, such as:
 //    vault://secret/prod-database?key=username
@@ -98,7 +101,7 @@ func (v EnvVault) ReadSecretValue(vaultURL string) (string, error) {
 	q := parsed.Query()
 	key := q["key"]
 	if key == nil {
-		key = []string{"value"}
+		key = []string{VaultDefaultKey}
 	}
 
 	value, ok := secret.Data[key[0]].(string)


### PR DESCRIPTION
This changes does the following:

* Define the default key to lookup as a const `VaultDefaultKey`
* Sort the environment variables in the log output

I found more readable to have the environment variables grouped in the log output by prefix, e.g.
 `EXECUTOR` vars, then `MESOS` vars, then `VAULT` vars using the [sort.Strings()](https://golang.org/pkg/sort/#Strings) function.