### PR TITLE
Full Hashicorp Vault integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ script:
   - golangci-lint run
   - go test -v ./... && (CGO_ENABLED=0 GOOS=linux go build -ldflags '-d')
 
+env:
+  - TMPDIR="."
+
 deploy:
   provider: releases
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,29 @@ with `EXECUTOR_`.
    with some fields defined in Docker labels? This is a comma-separated list
    of labels. They will be sent with the field name being the Docker label name.
 
+Vault Configuration
+-------------------
+
+Because the executor uses the Vault library, it lets the Vault client configure
+itself from its own environment settings. You can look these up in the Vault
+[source](https://github.com/hashicorp/vault/blob/master/api/client.go#L28) if
+you'd like to see them all. The executor adds a couple of others to better
+control the Vault integration. You should specify at least the following:
+
+ * `VAULT_ADDR` - URL of the Vault server.
+ * `VAULT_MAX_RETRIES` - API retries before Vault fails.
+ * `VAULT_TOKEN` - Optional if specified in a file or using userpass.
+ * `VAULT_TOKEN_FILE` - Where to cache Vault tokens between calls to the executor
+   on the same host.
+ * `VAULT_TTL` - The TTL in seconds of the Vault Token we'll have issued note that
+   the grace period is one hour so shorter than 1 hour is not possible.
+
+**WARNING** If you are using Vault, you _really_ want to have the executor cache
+tokens to a `VAULT_TOKEN_FILE`. If not you can build up quite a lot of tokens
+in Vault, and that doesn't work well. Especially in a fast job failure scenario
+where executors running on multiple machines might be generating tokens
+constantly.
+
 Configuring Docker Connectivity
 -------------------------------
 

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+
 func Test_shouldCheckSidecar(t *testing.T) {
 	Convey("When checking if Sidecar is enabled", t, func() {
 

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -417,6 +417,7 @@ func Test_ExecutorCallbacks(t *testing.T) {
 				So(sidecarStateCalls, ShouldEqual, 1)
 			})
 
+
 			Convey("fails to launch a task", func() {
 				Convey("when it fails to pull an image", func() {
 					dummyDockerClient.PullImageShouldError = true

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -417,7 +417,6 @@ func Test_ExecutorCallbacks(t *testing.T) {
 				So(sidecarStateCalls, ShouldEqual, 1)
 			})
 
-
 			Convey("fails to launch a task", func() {
 				Convey("when it fails to pull an image", func() {
 					dummyDockerClient.PullImageShouldError = true

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -50,7 +50,7 @@ func Test_relayLogs(t *testing.T) {
 
 			exec.relayLogs(quitChan, "deadbeef123123123", map[string]string{}, result)
 
-			resultBytes, _ := ioutil.ReadFile("/tmp/asdf")
+			resultBytes, _ := ioutil.ReadFile(tmpfn)
 			So(string(resultBytes), ShouldContainSubstring, "some stdout text")
 			So(string(resultBytes), ShouldContainSubstring, "some stderr text")
 			result.Close()
@@ -71,7 +71,7 @@ func Test_relayLogs(t *testing.T) {
 			exec.relayLogs(quitChan, "deadbeef123123123", labels, result)
 			exec.config.ContainerLogsStdout = true
 
-			resultBytes, _ := ioutil.ReadFile("/tmp/asdf1")
+			resultBytes, _ := ioutil.ReadFile(tmpfn)
 			So(string(resultBytes), ShouldContainSubstring, `"Environment":"prod"`)
 			So(string(resultBytes), ShouldContainSubstring, `"ServiceName":"beowulf"`)
 			result.Close()

--- a/mesosdriver/executor_driver_test.go
+++ b/mesosdriver/executor_driver_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+
 type MockDelegate struct{}
 
 func (m *MockDelegate) LaunchTask(taskInfo *mesos.TaskInfo) {}

--- a/vault/vault_auth.go
+++ b/vault/vault_auth.go
@@ -1,0 +1,172 @@
+package vault
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultTokenTTL  = 86400 // 1 day
+	TokenGracePeriod = 3600  // 1 hour
+)
+
+// Wrapper for parts of the Hashicorp Vault API we have to do more
+// work with before calling. Covers over some parts of the API that
+// are hard to mock.
+type TokenAuthHandler interface {
+	Validate(token string) (*api.Secret, error)
+	Login(username string, password string, options map[string]interface{}) (string, error)
+	SetToken(token string)
+}
+
+// vaultTokenAuthHandler is an implementation of TokenAuthHandler to do the
+// actual work of auth with the Vault API.
+type vaultTokenAuthHandler struct {
+	client *api.Client
+}
+
+// Validate is a wrapper for Vault method calls so we can mock them
+// in tests.
+func (f *vaultTokenAuthHandler) Validate(token string) (*api.Secret, error) {
+	f.client.SetToken(token)
+	return f.client.Auth().Token().LookupSelf()
+}
+
+// SetToken is just a pass through to Vault client SetToken()
+func (f *vaultTokenAuthHandler) SetToken(token string) {
+	f.client.SetToken(token)
+}
+
+// Login does the actual work of authenticating with a username and
+// password. Makes it so we can mock out part of the call.
+func (f *vaultTokenAuthHandler) Login(username string, password string,
+	options map[string]interface{}) (string, error) {
+
+	path := fmt.Sprintf("auth/userpass/login/%s", username)
+	secret, err := f.client.Logical().Write(path, options)
+	if err != nil {
+		return "", fmt.Errorf("Error logging in: %s", err)
+	}
+	if secret == nil {
+		return "", fmt.Errorf("Empty response from credential provider")
+	}
+
+	log.Info("Successfully authenticated with Vault")
+
+	token, err := secret.TokenID()
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// GetToken uses username and password auth to get a Vault Token
+func GetToken(client TokenAuthHandler) (err error) {
+	var token string
+
+	if tokenFile := os.Getenv("VAULT_TOKEN_FILE"); tokenFile != "" {
+		token, err = GetTokenFromFile(tokenFile)
+	}
+
+	if err == nil && token != "" {
+		// Reach out to the API to make sure it's good
+		t, err := client.Validate(token)
+
+		if err == nil && t != nil {
+			client.SetToken(token)
+			return nil
+		}
+
+		log.Warn("Retrieved token is not valid, falling back")
+	}
+
+	if err != nil {
+		log.Warn(err.Error())
+	}
+
+	// Fall back to logging in with user/pass creds
+	token, err = GetTokenWithLogin(client)
+	if err != nil {
+		return err
+	}
+
+	client.SetToken(token)
+	return nil
+}
+
+// GetTokenFromFile attempts to read a token from the Vault token file as
+// specified in the environment.
+func GetTokenFromFile(tokenFile string) (string, error) {
+	file, err := os.Stat(tokenFile)
+	if err != nil {
+		return "", fmt.Errorf("Failed to stat token file %s, falling back to login", tokenFile)
+	}
+
+	ttl := time.Duration(GetTTL())
+	expiryTime := time.Now().Add((0 - ttl + TokenGracePeriod) * time.Second)
+
+	if file.ModTime().Before(expiryTime) {
+		return "", errors.New("Token too close to expiry")
+	}
+
+	rawToken, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return "", err
+	}
+
+	log.Infof("Re-using Vault token from token file: %s", tokenFile)
+
+	return strings.TrimSpace(string(rawToken)), nil
+}
+
+func GetTTL() int {
+	var ttl int = DefaultTokenTTL
+
+	if vaultTTL := os.Getenv("VAULT_TTL"); vaultTTL != "" {
+		ttl, _ = strconv.Atoi(vaultTTL)
+	}
+
+	return ttl
+}
+
+// GetTokenWithLogin calls out to the Vault API and authenticates with userpass
+// credentials.
+func GetTokenWithLogin(client TokenAuthHandler) (string, error) {
+	username := os.Getenv("VAULT_USERNAME")
+	password := os.Getenv("VAULT_PASSWORD")
+
+	if username == "" || password == "" {
+		return "", fmt.Errorf("Must set VAULT_USERNAME and VAULT_PASSWORD")
+	}
+
+	ttl := GetTTL()
+
+	options := map[string]interface{}{
+		"password": password,
+		"ttl":      ttl,
+		"max_ttl":  ttl,
+	}
+
+	token, err := client.Login(username, password, options)
+	if err != nil {
+		return "", err // Errors are nicely wrapped already
+	}
+
+	if tokenFile := os.Getenv("VAULT_TOKEN_FILE"); tokenFile != "" {
+		err = ioutil.WriteFile(tokenFile, []byte(token), 0600)
+		if err != nil {
+			log.Errorf("Error writing Vault token file: %s", err)
+		}
+	}
+
+	return token, nil
+}

--- a/vault/vault_auth_test.go
+++ b/vault/vault_auth_test.go
@@ -1,0 +1,197 @@
+package vault
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"errors"
+
+	"github.com/hashicorp/vault/api"
+	log "github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_GetTokenFromFile(t *testing.T) {
+	Convey("GetTokenFromFile()", t, func() {
+		log.SetOutput(ioutil.Discard)
+		tmpdir, _ := ioutil.TempDir("", "testing")
+		tmpfn := filepath.Join(tmpdir, "vault-token")
+
+		Convey("Reads a file if it exists", func() {
+			err := ioutil.WriteFile(tmpfn, []byte("bogus_data"), 0600)
+			So(err, ShouldBeNil)
+			token, err := GetTokenFromFile(tmpfn)
+			So(err, ShouldBeNil)
+			So(token, ShouldEqual, "bogus_data")
+		})
+
+		Convey("Returns an error when the file is missing", func() {
+			token, err := GetTokenFromFile(tmpfn)
+			So(err.Error(), ShouldContainSubstring, "Failed to stat")
+			So(token, ShouldEqual, "")
+		})
+		// TODO no clean way to test expiry ATM as it depends on file ModTime
+		// too invasive to mock as-is.
+	})
+}
+
+func Test_GetTTL(t *testing.T) {
+	Convey("GetTTL()", t, func() {
+		Convey("Returns the default value when the env var is not set", func() {
+			So(GetTTL(), ShouldEqual, DefaultTokenTTL)
+		})
+
+		Convey("Returns the specified value if set", func() {
+			Reset(func() { os.Unsetenv("VAULT_TTL") })
+
+			os.Setenv("VAULT_TTL", "666")
+			So(GetTTL(), ShouldEqual, 666)
+		})
+	})
+}
+
+func Test_GetToken(t *testing.T) {
+	Convey("GetToken()", t, func() {
+		mock := &mockTokenAuthHandler{}
+		ttl := GetTTL()
+
+		Convey("when VAULT_TOKEN_FILE is NOT set", func() {
+			os.Unsetenv("VAULT_TOKEN_FILE")
+
+			os.Setenv("VAULT_USERNAME", "lancelot")
+			os.Setenv("VAULT_PASSWORD", "guinevere")
+
+			Reset(func() {
+				os.Unsetenv("VAULT_USERNAME")
+				os.Unsetenv("VAULT_PASSWORD")
+			})
+
+			Convey("goes straight to Login", func() {
+				mock.token = "from_login"
+
+				err := GetToken(mock)
+				So(err, ShouldBeNil)
+				So(mock.LoginWasCalled, ShouldBeTrue)
+				So(mock.ValidateWasCalled, ShouldBeFalse)
+				So(mock.token, ShouldEqual, "from_login")
+				So(mock.loginOptions["password"], ShouldEqual, "guinevere")
+				So(mock.loginOptions["ttl"], ShouldEqual, ttl)
+				So(mock.loginOptions["max_ttl"], ShouldEqual, ttl)
+			})
+
+			Convey("errors when Login fails", func() {
+				mock.token = "from_login"
+				mock.LoginShouldError = true
+
+				err := GetToken(mock)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "intentional error")
+				So(mock.LoginWasCalled, ShouldBeTrue)
+				So(mock.ValidateWasCalled, ShouldBeFalse)
+				So(mock.token, ShouldEqual, "from_login") // check it _wasn't_ overwritten
+			})
+
+			Convey("errors when env vars aren't set", func() {
+				os.Unsetenv("VAULT_USERNAME")
+				os.Unsetenv("VAULT_PASSWORD")
+
+				mock.token = "from_login"
+
+				err := GetToken(mock)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "set VAULT_USERNAME and VAULT_PASSWORD")
+				So(mock.LoginWasCalled, ShouldBeFalse)
+				So(mock.ValidateWasCalled, ShouldBeFalse)
+				So(mock.token, ShouldEqual, "from_login") // check it _wasn't_ overwritten
+			})
+		})
+
+		Convey("when VAULT_TOKEN_FILE is set", func() {
+			tmpdir, _ := ioutil.TempDir("", "testing")
+			tmpfn := filepath.Join(tmpdir, "vault-token")
+
+			os.Setenv("VAULT_TOKEN_FILE", tmpfn)
+			os.Setenv("VAULT_USERNAME", "lancelot")
+			os.Setenv("VAULT_PASSWORD", "guinevere")
+
+			Reset(func() {
+				os.Unsetenv("VAULT_TOKEN_FILE")
+				os.Unsetenv("VAULT_USERNAME")
+				os.Unsetenv("VAULT_PASSWORD")
+			})
+
+			Convey("sets a token from the file when present", func() {
+				err := ioutil.WriteFile(tmpfn, []byte("bogus_data"), 0600)
+				So(err, ShouldBeNil)
+				mock.ValidateShouldError = false
+
+				err = GetToken(mock)
+				So(err, ShouldBeNil)
+				So(mock.LoginWasCalled, ShouldBeFalse)
+				So(mock.ValidateWasCalled, ShouldBeTrue)
+				So(mock.token, ShouldEqual, "bogus_data")
+			})
+
+			Convey("falls back to userpass when the file is invalid", func() {
+				err := ioutil.WriteFile(tmpfn, []byte("bogus_data"), 0600)
+				So(err, ShouldBeNil)
+				mock.ValidateShouldError = true
+
+				err = GetToken(mock)
+				So(err, ShouldBeNil)
+				So(mock.LoginWasCalled, ShouldBeTrue)
+				So(mock.ValidateWasCalled, ShouldBeTrue)
+				So(mock.token, ShouldEqual, "")
+			})
+
+			Convey("falls back to userpass when the file is missing", func() {
+				// We don't write the file, so the error should bubble up
+				err := GetToken(mock)
+				So(err, ShouldBeNil)
+				So(mock.LoginWasCalled, ShouldBeTrue)
+				So(mock.ValidateWasCalled, ShouldBeFalse)
+			})
+		})
+	})
+}
+
+type mockTokenAuthHandler struct {
+	token             string
+
+	LoginWasCalled    bool
+	ValidateWasCalled bool
+	SetTokenWasCalled bool
+
+	LoginShouldError    bool
+	ValidateShouldError bool
+
+	loginOptions map[string]interface{}
+}
+
+func (m *mockTokenAuthHandler) Validate(token string) (*api.Secret, error) {
+	m.ValidateWasCalled = true
+	if m.ValidateShouldError {
+		return nil, errors.New("intentional error")
+	}
+
+	return &api.Secret{}, nil
+}
+
+func (m *mockTokenAuthHandler) Login(username string, password string,
+	options map[string]interface{}) (string, error) {
+
+	m.loginOptions = options
+	m.LoginWasCalled = true
+	if m.LoginShouldError {
+		return "", errors.New("intentional error")
+	}
+
+	return m.token, nil
+}
+
+func (m *mockTokenAuthHandler) SetToken(token string) {
+	m.token = token
+	m.SetTokenWasCalled = true
+}


### PR DESCRIPTION
This builds on the existing Vault integration by moving all the login and auth code into the executor itself in Go, rather than relying on the external scripting to provider a valid token. Currently supports userpass auth, which is what has been supported in the shell script.