### PR TITLE
Add hostname to logging fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ RelaySyslog             | false
 SyslogAddr              | 127.0.0.1:514
 ContainerLogsStdout     | false
 SendDockerLabels        | []
+LogHostname             | System Hostname
 
 All of the environment variables are of the form `EXECUTOR_SIDECAR_RETRY_DELAY`
 where all of the CamelCased words are split apart, and each setting is prefixed
@@ -203,6 +204,10 @@ with `EXECUTOR_`.
  * **SendDockerLabels**: If `RelaySyslog` is true, should we augment JSON logs
    with some fields defined in Docker labels? This is a comma-separated list
    of labels. They will be sent with the field name being the Docker label name.
+
+ * **LogHostname**: When relaying logs, we will add this as the `Hostname`
+   field. Defaults to the OS hostname and can be overridden with `LOG_HOSTNAME`
+   in the environment.
 
 Vault Configuration
 -------------------

--- a/log_relay.go
+++ b/log_relay.go
@@ -35,12 +35,13 @@ func (exec *sidecarExecutor) configureLogRelay(containerId string,
 
 	// Loop through the fields we're supposed to pass, and add them from the
 	// Docker labels on this container
-	fields := make(log.Fields, len(exec.config.SendDockerLabels))
+	fields := make(log.Fields, len(exec.config.SendDockerLabels) + 1)
 	for _, field := range exec.config.SendDockerLabels {
 		if val, ok := labels[field]; ok {
 			fields[field] = val
 		}
 	}
+	fields["Hostname"] = exec.config.LogHostname
 
 	return syslogger.WithFields(fields)
 }

--- a/log_relay.go
+++ b/log_relay.go
@@ -33,9 +33,11 @@ func (exec *sidecarExecutor) configureLogRelay(containerId string,
 	})
 	syslogger.SetOutput(output)
 
+	// Add one to the labels length to account for hostname
+	fields := make(log.Fields, len(exec.config.SendDockerLabels) + 1)
+
 	// Loop through the fields we're supposed to pass, and add them from the
 	// Docker labels on this container
-	fields := make(log.Fields, len(exec.config.SendDockerLabels) + 1)
 	for _, field := range exec.config.SendDockerLabels {
 		if val, ok := labels[field]; ok {
 			fields[field] = val

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type Config struct {
 	SyslogAddr          string   `envconfig:"SYSLOG_ADDR" default:"127.0.0.1:514"`
 	ContainerLogsStdout bool     `envconfig:"CONTAINER_LOGS_STDOUT" default:"false"`
 	SendDockerLabels    []string `envconfig:"SEND_DOCKER_LABELS" default:""`
+	LogHostname         string   `envconfig:"LOG_HOSTNAME"` // Name we log as
 }
 
 type Vault interface {
@@ -99,6 +100,7 @@ func logConfig(config Config) {
 	log.Infof(" * SyslogAddr:              %s", config.SyslogAddr)
 	log.Infof(" * ContainerLogsStdout:     %t", config.ContainerLogsStdout)
 	log.Infof(" * SendDockerLabels:        %v", config.SendDockerLabels)
+	log.Infof(" * LogHostname:             %s", config.LogHostname)
 	log.Infof(" * Debug:                   %t", config.Debug)
 
 	log.Infof("Environment ---------------------------")
@@ -210,6 +212,12 @@ func initConfig() (Config, error) {
 	err := envconfig.Process("executor", &config)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to process envconfig: %s", err)
+	}
+
+	if len(config.LogHostname) < 1 {
+		// What would we do if this errored, anyway? So, just ignore it
+		hostname, _ := os.Hostname()
+		config.LogHostname = hostname
 	}
 
 	log.SetOutput(os.Stdout)


### PR DESCRIPTION
This sends a `Hostname` field in the JSON logs for situations where the logging system does not expose the source hostname. It defaults to `os.Hostname()` but can be overridden with the `LOG_HOSTNAME` env var.