### PR TITLE
Fix blocking Decode() call

### DIFF
--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-
 func Test_shouldCheckSidecar(t *testing.T) {
 	Convey("When checking if Sidecar is enabled", t, func() {
 

--- a/log_relay.go
+++ b/log_relay.go
@@ -34,7 +34,7 @@ func (exec *sidecarExecutor) configureLogRelay(containerId string,
 	syslogger.SetOutput(output)
 
 	// Add one to the labels length to account for hostname
-	fields := make(log.Fields, len(exec.config.SendDockerLabels) + 1)
+	fields := make(log.Fields, len(exec.config.SendDockerLabels)+1)
 
 	// Loop through the fields we're supposed to pass, and add them from the
 	// Docker labels on this container

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -94,7 +94,7 @@ func Test_relayLogs(t *testing.T) {
 
 			resultBytes, _ := ioutil.ReadFile(tmpfn)
 			So(exec.config.LogHostname, ShouldNotBeEmpty)
-			So(string(resultBytes), ShouldContainSubstring, `"Hostname":"` + exec.config.LogHostname)
+			So(string(resultBytes), ShouldContainSubstring, `"Hostname":"`+exec.config.LogHostname)
 		})
 	})
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -12,8 +13,6 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-
-	"fmt"
 
 	"github.com/Nitro/sidecar-executor/mesosdriver"
 	"github.com/Nitro/sidecar/service"

--- a/mesosdriver/executor_driver.go
+++ b/mesosdriver/executor_driver.go
@@ -163,7 +163,7 @@ func (driver *ExecutorDriver) buildEventHandler() events.Handler {
 
 		executor.Event_SHUTDOWN: func(_ context.Context, e *executor.Event) error {
 			log.Info("Shutting down the executor")
-			close(driver.quitChan)
+			driver.Stop()
 			return nil
 		},
 

--- a/mesosdriver/executor_driver.go
+++ b/mesosdriver/executor_driver.go
@@ -82,7 +82,9 @@ func (driver *ExecutorDriver) unacknowledgedUpdates() (result []executor.Call_Up
 
 // eventLoop is the main handler event loop of the driver. Called from Run()
 func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
-	h events.Handler) (err error) {
+	h events.Handler) error {
+
+	var err error
 
 	log.Info("Entering event loop")
 	ctx := context.Background()
@@ -92,7 +94,7 @@ func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
 	go func() {
 		for {
 			var e executor.Event
-			if err = decoder.Decode(&e); err == nil {
+			if err := decoder.Decode(&e); err == nil {
 				err = h.HandleEvent(ctx, &e)
 			}
 
@@ -109,16 +111,16 @@ func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
 		case <-driver.quitChan:
 			log.Info("Event loop canceled")
 			return nil
-		case err := <-event:
+		case err = <-event:
 			if err != nil {
-				return err
+				break
 			}
 		}
 	}
 
 	log.Info("Exiting event loop")
 
-	return nil
+	return err
 }
 
 // buildEventHandler returns an events.Handler that has been set up with

--- a/mesosdriver/executor_driver.go
+++ b/mesosdriver/executor_driver.go
@@ -93,8 +93,9 @@ func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
 
 	go func() {
 		for {
+			var err error
 			var e executor.Event
-			if err := decoder.Decode(&e); err == nil {
+			if err = decoder.Decode(&e); err == nil {
 				err = h.HandleEvent(ctx, &e)
 			}
 
@@ -106,6 +107,7 @@ func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
 		}
 	}()
 
+OUTER:
 	for {
 		select {
 		case <-driver.quitChan:
@@ -113,7 +115,7 @@ func (driver *ExecutorDriver) eventLoop(decoder encoding.Decoder,
 			return nil
 		case err = <-event:
 			if err != nil {
-				break
+				break OUTER
 			}
 		}
 	}

--- a/mesosdriver/executor_driver.go
+++ b/mesosdriver/executor_driver.go
@@ -25,7 +25,6 @@ import (
 const (
 	agentAPIPath      = "/api/v1/executor"
 	driverHttpTimeout = 10 * time.Second
-	driverSendTimeout = 2 * time.Second
 )
 
 // A TaskDelegate is responsible for launching and killing tasks

--- a/mesosdriver/executor_driver_test.go
+++ b/mesosdriver/executor_driver_test.go
@@ -26,7 +26,6 @@ func Test_NewExecutorDriver(t *testing.T) {
 			So(driver.cli, ShouldNotBeNil)
 			So(driver.unackedTasks, ShouldNotBeNil)
 			So(driver.unackedUpdates, ShouldNotBeNil)
-			So(driver.failedTasks, ShouldNotBeNil)
 			So(driver.delegate, ShouldEqual, mockDelegate)
 			So(driver.cfg, ShouldEqual, mesosConfig)
 			So(driver.subscriber, ShouldNotBeNil)


### PR DESCRIPTION
When a task would die out from under the executor, it would block on the call to `Decode()` since no event was available to decode. This, in turn, caused the executor not to actually exit, even though the `Failed` message was delivered to Mesos. The result was executors left running on the node, using up file descriptors on the Mesos agent. When this hit the ulimit, the agent would disconnect from Mesos and the node would go offline. This fixes that problem by moving to a correct quit channel implementation and moving the `Decode()` operation (which doesn't accept a context!) to a goroutine we can cancel.