### PR TITLE
Refactor core task lifecycle

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -251,8 +251,8 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 		time.Sleep(exec.config.SidecarBackoff)
 	}
 
-	// watcherWg is used to let the Sidecar draining exit early if
-	// the process exits
+	// watcherWg is used to let the Sidecar draining exit early if the
+	// container exits
 	exec.watcherWg.Add(1)
 
 	containerName := container.GetContainerName(&taskInfo.TaskID)
@@ -281,6 +281,12 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 			}
 		}
 	}
+
+	// We have to check one more time if it still reports as running
+	if exitCode == StillRunning {
+		exitCode, err = exec.checkContainerStatus(cntnrId, checkSidecar)
+	}
+
 	// Release any goroutines waiting for the watcher to complete
 	exec.watcherWg.Done()
 

--- a/executor.go
+++ b/executor.go
@@ -20,6 +20,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	StillRunning = -1
+)
+
 // ExecDriver narrowly scopes the interface we expect from a driver. It is
 // implemented by the ExecutorDriver.
 type ExecDriver interface {
@@ -124,61 +128,18 @@ func (exec *sidecarExecutor) failTask(taskInfo *mesos.TaskInfo) {
 	exec.StopDriver()
 }
 
-// Loop on a timed basis and check the health of the process in Sidecar.
-// Note that because of the way the retries work, the loop timing is a
-// lower bound on the delay.
-func (exec *sidecarExecutor) watchContainer(containerId string, checkSidecar bool) {
-	log.Infof("Watching container %s [checkSidecar: %t]", containerId[:12], checkSidecar)
-	if checkSidecar {
-		time.Sleep(exec.config.SidecarBackoff)
-	}
+// taskKilled tells Mesos and the framework that the task was killed. Shutdown driver.
+func (exec *sidecarExecutor) taskKilled(taskInfo *mesos.TaskInfo) {
+	taskID := taskInfo.GetTaskID()
+	exec.sendStatus(TaskKilled, &taskID)
 
-	exec.watchLooper.Loop(func() error {
-		containers, err := exec.client.ListContainers(
-			docker.ListContainersOptions{},
-		)
-		if err != nil {
-			return err
-		}
+	// Unfortunately the status updates are sent async and we can't
+	// get a handle on the channel used to send them. So we wait
+	time.Sleep(exec.statusSleepTime)
 
-		// Loop through all the running containers, looking for a running
-		// container with our Id.
-		ok := false
-		for _, entry := range containers {
-			if entry.ID == containerId {
-				ok = true
-				break
-			}
-		}
-		if !ok {
-			exitCode, err := container.GetExitCode(exec.client, containerId)
-
-			if err != nil {
-				return err
-			}
-
-			msg := fmt.Sprintf("Container %s not running! - ExitCode: %d", containerId, exitCode)
-			if exitCode == 0 {
-				log.Infof(msg)
-				exec.watchLooper.Done(nil)
-				return nil
-			}
-
-			return errors.New(msg)
-		}
-
-		if !checkSidecar {
-			return nil
-		}
-
-		// Validate health status with Sidecar
-		if err = exec.sidecarStatus(containerId); err != nil {
-			return err
-		}
-
-		return nil
-	})
+	exec.StopDriver()
 }
+
 
 // Lookup a container in a service list
 func sidecarLookup(containerId string, services SidecarServices) (*service.Service, bool) {
@@ -276,6 +237,138 @@ func (exec *sidecarExecutor) sidecarStatus(containerId string) error {
 	exec.failCount = 0 // Reset because we were healthy!
 
 	return nil
+}
+
+// monitorTask runs in a goroutine and hangs out, waiting for the watchLooper to
+// complete. When it completes, it handles the Docker and Mesos interactions.
+func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInfo, checkSidecar bool) {
+	log.Infof("Monitoring Mesos task %s for container %s [checkSidecar: %t]",
+		taskInfo.TaskID.Value, cntnrId[:12], checkSidecar,
+	)
+
+	// Wait for Sidecar backoff interval
+	if checkSidecar {
+		time.Sleep(exec.config.SidecarBackoff)
+	}
+
+	// watcherWg is used to let the Sidecar draining exit early if
+	// the process exits
+	exec.watcherWg.Add(1)
+
+	containerName := container.GetContainerName(&taskInfo.TaskID)
+
+	// Note that because of the way the retries work, the loop timing is a
+	// lower bound on the delay.
+	var exitCode int = StillRunning
+	go exec.watchLooper.Loop(func() error {
+		var err error
+		exitCode, err = exec.checkContainerStatus(cntnrId, checkSidecar)
+		return err
+	})
+
+	err := exec.watchLooper.Wait()
+
+	if err != nil {
+		log.Errorf("Error! %s", err)
+
+		if exitCode == StillRunning {
+			// Something went wrong, we better take this thing out!
+			err := container.StopContainer(
+				exec.client, containerName, exec.config.KillTaskTimeout,
+			)
+			if err != nil {
+				log.Errorf("Error stopping container %s! %s", containerName, err)
+			}
+		}
+	}
+	// Release any goroutines waiting for the watcher to complete
+	exec.watcherWg.Done()
+
+	exec.handleContainerExit(taskInfo, exitCode)
+}
+
+func (exec *sidecarExecutor) handleContainerExit(taskInfo *mesos.TaskInfo, exitCode int) {
+	if exitCode != 0 {
+		containerName := container.GetContainerName(&taskInfo.TaskID)
+		// Copy the failure logs (hopefully) to stdout/stderr so we can get them
+		exec.copyLogs(containerName)
+	}
+
+	switch code := exitCode; {
+	case code == 137:
+		log.Error("Task was killed, notifying Mesos")
+
+		// Notify Mesos
+		exec.taskKilled(taskInfo)
+	case code > 0:
+		log.Error("Task failed, notifying Mesos")
+
+		// Notify Mesos
+		exec.failTask(taskInfo)
+	case code < 0:
+		log.Error("Task may still be running despite attempts to kill!")
+
+		// Notify Mesos
+		exec.failTask(taskInfo)
+	default:
+		log.Info("Task completed: ", taskInfo.GetName())
+		exec.finishTask(taskInfo)
+	}
+}
+
+// checkContainerStatus is called on a timed basis and checks the health of the
+// process in Sidecar.
+func (exec *sidecarExecutor) checkContainerStatus(containerId string, checkSidecar bool) (int, error) {
+	containers, err := exec.client.ListContainers(
+		docker.ListContainersOptions{},
+	)
+	if err != nil {
+		return StillRunning, err
+	}
+
+	// Loop through all the running containers, looking for a running container
+	// with our Id.
+	if !containerIsPresent(containers, containerId) {
+		exec.watchLooper.Quit() // Will cause looper to exit on next iter
+
+		exitCode, err := container.GetExitCode(exec.client, containerId)
+		if err != nil {
+			return StillRunning, err
+		}
+
+		msg := fmt.Sprintf("Container %s not running! - ExitCode: %d", containerId, exitCode)
+		if exitCode == 0 {
+			log.Info(msg)
+			return 0, nil
+		}
+
+		return exitCode, errors.New(msg)
+	}
+
+	// It was present, so we're either good, or we report the status from Sidecar
+	return StillRunning, exec.maybeCheckSidecar(containerId, checkSidecar)
+}
+
+// maybeCheckSidecar will get the container status from Sidecar if we're
+// configured to monitor it.
+func (exec *sidecarExecutor) maybeCheckSidecar(containerId string, checkSidecar bool) error {
+	if !checkSidecar {
+		return nil
+	}
+
+	// Validate health status with Sidecar
+	return exec.sidecarStatus(containerId)
+}
+
+// containerIsPresent checks a list of container for the current container
+func containerIsPresent(containers []docker.APIContainers, containerId string) bool {
+	for _, entry := range containers {
+		if entry.ID == containerId {
+			return true
+		}
+	}
+
+	return false
 }
 
 // StopDriver flags the event loop to exit on the next time around

--- a/executor.go
+++ b/executor.go
@@ -285,6 +285,9 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 	// We have to check one more time if it still reports as running
 	if exitCode == StillRunning {
 		exitCode, err = exec.checkContainerStatus(cntnrId, checkSidecar)
+		if err != nil {
+			log.Error("Unable to check container status! Assuming dead, moving on.")
+		}
 	}
 
 	// Release any goroutines waiting for the watcher to complete
@@ -294,6 +297,7 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 }
 
 func (exec *sidecarExecutor) handleContainerExit(taskInfo *mesos.TaskInfo, exitCode int) {
+	// On failed/killed tasks, we want to grab the logs and play them into Mesos
 	if exitCode != 0 {
 		containerName := container.GetContainerName(&taskInfo.TaskID)
 		// Copy the failure logs (hopefully) to stdout/stderr so we can get them

--- a/executor.sh
+++ b/executor.sh
@@ -54,4 +54,4 @@ function cleanup {
 # Always run cleanup when the executor exits
 trap cleanup EXIT
 
-$executor -logtostderr=true
+$executor -logtostderr=true "                                  "

--- a/executor_utils.go
+++ b/executor_utils.go
@@ -13,43 +13,8 @@ import (
 
 	"github.com/Nitro/sidecar-executor/container"
 	"github.com/fsouza/go-dockerclient"
-	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	log "github.com/sirupsen/logrus"
 )
-
-// monitorTask runs in a goroutine and hangs out, waiting for the watchLooper to
-// complete. When it completes, it handles the Docker and Mesos interactions.
-func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInfo) {
-	log.Infof("Monitoring Mesos task %s for container %s",
-		taskInfo.TaskID.Value,
-		cntnrId,
-	)
-
-	exec.watcherWg.Add(1)
-	containerName := container.GetContainerName(&taskInfo.TaskID)
-	// Wait on the watchLooper to return a status
-	err := exec.watchLooper.Wait()
-	if err != nil {
-		log.Errorf("Error! %s", err)
-		// Something went wrong, we better take this thing out!
-		err := container.StopContainer(exec.client, containerName, exec.config.KillTaskTimeout)
-		if err != nil {
-			log.Errorf("Error stopping container %s! %s", containerName, err)
-		}
-		// Copy the failure logs (hopefully) to stdout/stderr so we can get them
-		exec.copyLogs(containerName)
-		// Notify Mesos
-		exec.failTask(taskInfo)
-		exec.watcherWg.Done()
-		return
-	}
-
-	// Release any goroutines waiting for the watcher to complete
-	exec.watcherWg.Done()
-
-	log.Info("Task completed: ", taskInfo.GetName())
-	exec.finishTask(taskInfo)
-}
 
 // copyLogs will copy the Docker container logs to stdout and stderr so we can
 // capture some failure information in the Mesos logs. Then tooling can fetch


### PR DESCRIPTION
The code for the executor has gotten more complex over time and the recent changes to the Mesos V1 API bindings didn't help simplify that. We keep running into some edge cases that aren't handled all that well. And we've always had rare occasions when the containers were left running on exit, hence the second cleanup attempt in the shell wrapper. Getting this right was harder for a couple of reasons:

1. Complexity of coordinating between two monitoring goroutines: 1 for the container and 1 for health checking
2. Complexity of exiting and getting final container status. This was handled in a couple of different places in a couple of different ways

This refactor merges the monitoring code into one place and centralizes all the exit handling. It should deliver a much more reliable experience.

**Note** that there are a few changes to behavior here:
1. When things are stopped from the scheduler they will still be reported to Mesos as "Finished" if they exited cleanly. Previously we would report "Killed" in that scenario, which isn't really right. Now "Killed" is reserved for when `container.StopContainer()` really does have to kill it with fire.
2. Better exit code handling so that we try to assign the correct status to all containers that were killed out from under us. This means that `TaskLost` will only be reported in the event that the agent is lost.