### PR TITLE
Break out of draining retries on container exit

### DIFF
--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -476,9 +476,11 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("tries multiple times to drain the service", func() {
+				exec.watcherWg.Add(1)
 				exec.config.SidecarRetryCount = 1
 				sidecarDrainFailOnce = true
 				exec.KillTask(&dummyTaskID)
+				exec.watcherWg.Done()
 				So(sidecarDrainCalls, ShouldEqual, 2)
 			})
 


### PR DESCRIPTION
This turns out to only be an issue if you are running Sidecar without support for draining. It's an edge case that probably doesn't warrant another release, but should get fixed. This just stops the attempts to drain the service in the event that the container has exited already.