### PR TITLE
Support CPU Shares as well as CFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,9 @@ with `EXECUTOR_`.
 
  * **UseCpuShares**: By default we use the Linux Completely Fair Scheduler
    settings to control CPU limiting. This doesn't work well for certain
-   workloads.  Should we instead use the older CPU Shares relative workload
+   workloads. Should we instead use the older CPU Shares relative workload
    limiting mechanism? Note that you should understand the difference before
-   turning this on. **Note** when this option is enabled, the Mesos Cpus
-   setting now ranges from 0 to 1 and represents a percentage total of system
-   CPU time.
+   turning this on. 
 
  * **Debug**: Should we turn on debug logging (verbose!) for this executor?
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ DockerRepository        | https://index.docker.io/v1/
 LogsSince               | 3m
 ForceCpuLimit           | false
 ForceMemoryLimit        | false
+UseCpuShares            | false
 Debug                   | false
 MesosMasterPort         | 5050
 RelaySyslog             | false
@@ -180,6 +181,14 @@ with `EXECUTOR_`.
 
  * **ForceMemoryLimit**: Should we enforce the memory limits in the request using
    cgroups (via Docker)?
+
+ * **UseCpuShares**: By default we use the Linux Completely Fair Scheduler
+   settings to control CPU limiting. This doesn't work well for certain
+   workloads.  Should we instead use the older CPU Shares relative workload
+   limiting mechanism? Note that you should understand the difference before
+   turning this on. **Note** when this option is enabled, the Mesos Cpus
+   setting now ranges from 0 to 1 and represents a percentage total of system
+   CPU time.
 
  * **Debug**: Should we turn on debug logging (verbose!) for this executor?
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -43,6 +43,7 @@ func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 		taskInfo,
 		exec.config.ForceCpuLimit,
 		exec.config.ForceMemoryLimit,
+		exec.config.UseCpuShares,
 		addEnvVars,
 	)
 

--- a/container/container.go
+++ b/container/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -200,7 +201,7 @@ func setCpuLimit(config *docker.CreateContainerOptions, taskInfo *mesos.TaskInfo
 
 	// Use CPU Shares if we ask for old-school CPU shares limiting
 	if useCpuShares {
-		multiplier := cpus.Scalar.Value
+		multiplier := cpus.Scalar.Value / float64(runtime.NumCPU())
 		if multiplier > 1.0 {
 			log.Errorf("CPUShares enabled, but CPUs value is more than 100%%. Scaling down to 1.0")
 			multiplier = 1.0

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -385,17 +385,15 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("hard limits CPUs to 1.0 when CPU Shares are enabled", func() {
-			opts := ConfigForTask(taskInfo, true, false, true, []string{})
-			So(opts.HostConfig.CPUShares, ShouldEqual, 512)
-		})
-
-		Convey("uses the command when it's set", func() {
 			taskInfo.Resources[0] = mesos.Resource{
 				Name:   "cpus",
 				Scalar: &mesos.Value_Scalar{Value: 35},
 			}
 			opts := ConfigForTask(taskInfo, true, false, true, []string{})
 			So(opts.HostConfig.CPUShares, ShouldEqual, 1024)
+		})
+
+		Convey("uses the command when it's set", func() {
 			So(opts.Config.Cmd, ShouldContain, "date")
 		})
 	})

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"bytes"
 	"io/ioutil"
+	"runtime"
 	"testing"
 	"time"
 
@@ -153,7 +154,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		image := "foo/foo:1.0.0"
 		command := []string{"date"}
 
-		cpus := float64(0.5)
+		cpus := float64(0.5) * float64(runtime.NumCPU())
 		memory := float64(128)
 
 		envValue := "SOMETHING=123=123"
@@ -286,8 +287,10 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("properly calculates the CPU limit", func() {
-			So(optsForced.HostConfig.CPUPeriod, ShouldEqual, float64(50000))
-			So(optsForced.HostConfig.CPUQuota, ShouldEqual, float64(25000))
+			So(optsForced.HostConfig.CPUPeriod, ShouldEqual, float64(defaultCpuPeriod))
+			So(optsForced.HostConfig.CPUQuota, ShouldEqual,
+				float64(defaultCpuPeriod * cpus),
+			)
 
 			So(opts.HostConfig.CPUPeriod, ShouldEqual, float64(0))
 			So(opts.HostConfig.CPUQuota, ShouldEqual, float64(0))

--- a/executor.go
+++ b/executor.go
@@ -140,7 +140,6 @@ func (exec *sidecarExecutor) taskKilled(taskInfo *mesos.TaskInfo) {
 	exec.StopDriver()
 }
 
-
 // Lookup a container in a service list
 func sidecarLookup(containerId string, services SidecarServices) (*service.Service, bool) {
 	hostname := os.Getenv("TASK_HOST") // Mesos supplies this

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ type Config struct {
 	LogsSince               time.Duration `envconfig:"LOGS_SINCE" default:"3m"`
 	ForceCpuLimit           bool          `envconfig:"FORCE_CPU_LIMIT" default:"false"`
 	ForceMemoryLimit        bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
+	UseCpuShares			bool		  `envconfig:"USE_CPU_SHARES" default:"false"`
 	Debug                   bool          `envconfig:"DEBUG" default:"false"`
 
 	// Mesos options
@@ -94,6 +95,7 @@ func logConfig(config Config) {
 	log.Infof(" * LogsSince:               %s", config.LogsSince.String())
 	log.Infof(" * ForceCpuLimit:           %t", config.ForceCpuLimit)
 	log.Infof(" * ForceMemoryLimit:        %t", config.ForceMemoryLimit)
+	log.Infof(" * UseCpuShares:            %t", config.UseCpuShares)
 	log.Infof(" * MesosMasterPort:         %s", config.MesosMasterPort)
 	log.Infof(" * RelaySyslog:             %t", config.RelaySyslog)
 	log.Infof(" * SyslogAddr:              %s", config.SyslogAddr)

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ type Config struct {
 	LogsSince               time.Duration `envconfig:"LOGS_SINCE" default:"3m"`
 	ForceCpuLimit           bool          `envconfig:"FORCE_CPU_LIMIT" default:"false"`
 	ForceMemoryLimit        bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
-	UseCpuShares			bool		  `envconfig:"USE_CPU_SHARES" default:"false"`
+	UseCpuShares            bool          `envconfig:"USE_CPU_SHARES" default:"false"`
 	Debug                   bool          `envconfig:"DEBUG" default:"false"`
 
 	// Mesos options


### PR DESCRIPTION
It turns out that, due to [this Linux kernel bug](https://lkml.org/lkml/2019/5/17/581), CFS CPU limits can cause weird behavior in some processes. Notably, we see this on Erlang/BEAM VMs running under almost no load. While CPU Shares are a MUCH cruder mechanism and not as fit for purpose they are perhaps currently a better choice in some scenarios. This patch allows the executor to support that mode via an env var setting.