### PR TITLE
Add retry support to PullImage()

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -93,7 +93,11 @@ func StopContainer(client DockerClient, containerId string, timeout uint) error 
 func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker.AuthConfiguration) error {
 	log.Infof("Pulling Docker image '%s'", taskInfo.Container.Docker.Image)
 
+	var numRetries int
+
 	err := retry.Do(func() error {
+		numRetries = numRetries + 1
+
 		err := client.PullImage(
 			docker.PullImageOptions{
 				Repository: taskInfo.Container.Docker.Image,
@@ -101,6 +105,8 @@ func PullImage(client DockerClient, taskInfo *mesos.TaskInfo, authConfig *docker
 			*authConfig,
 		)
 		if err != nil {
+			log.Warnf("Pull failed (retry %d/%d): %s", numRetries, PullImageNumRetries, err)
+
 			return err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.11
 	github.com/Nitro/sidecar v2.0.1+incompatible
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
+	github.com/avast/retry-go v2.4.3+incompatible
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808
 	github.com/docker/docker v0.7.3-0.20180827131323-0c5f8d2b9b23
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Nitro/sidecar v2.0.1+incompatible h1:d0YRUlFGQeczl+cQ5GWql+azLIFy6wG5
 github.com/Nitro/sidecar v2.0.1+incompatible/go.mod h1:lvA3xI7J4oCWr+9ortOFUzVgHM2nhXmys47N2TPq0P8=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/avast/retry-go v2.4.3+incompatible h1:c/FTk2POrEQyZfaHBMkMrXdu3/6IESJUHwu8r3k1JEU=
+github.com/avast/retry-go v2.4.3+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/containerd/continuity v0.0.0-20180814194400-c7c5070e6f6e/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=


### PR DESCRIPTION
Hi!

We've been seeing (seemingly) random docker image pull failures that are likely
caused by intermittent network failures.

This adds support for retrying a docker image pull if an error is encountered.

I am using the `go-retry` lib which I've previously used in other software
running in prod envs. Image pulling is configured to:

* Retry 5 times
* With exponential backoff of 100ms (`config.delay * (1 << n)`)
    * Which will be max 3.2s

cc @relistan 