### PR TITLE
Don't log errors for heartbeats

### DIFF
--- a/mesosdriver/executor_driver.go
+++ b/mesosdriver/executor_driver.go
@@ -174,6 +174,14 @@ func (driver *ExecutorDriver) buildEventHandler() events.Handler {
 			)
 
 		},
+
+		executor.Event_HEARTBEAT: func(_ context.Context, e *executor.Event) error {
+			// We don't process heartbeats. In theory we ought to count how many we get
+			// and force reconnect if we don't get one. But we already watch the
+			// connection so it's just redundant. Ignore.
+			log.Debug("Heartbeat received")
+			return nil
+		},
 	}.Otherwise(func(_ context.Context, e *executor.Event) error {
 		log.Error("unexpected event", e)
 		return nil


### PR DESCRIPTION
Newer Mesos agents send heartbeats to the executor so you can detect that a connection is down and reconnect. We don't really have to do this because we run one executor per task and the worst case scenario is that one task is lost and restarted. Also, we already watch and reconnect if the connection is down, so not really needed. But we were logging errors for every heartbeat:

```
time="2020-01-19T10:50:30Z" level=error msg="unexpected event&Event{Type:HEARTBEAT,Subscribed:nil,Acknowledged:nil,Launch:nil,Kill:nil,Message:nil,Error:nil,LaunchGroup:nil,}"
```
This patch just stops logging errors and sets some debugging logging for them if we want to turn it on.