### PR TITLE
Allow relaying logs for app startup only

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ UseCpuShares            | false
 Debug                   | false
 MesosMasterPort         | 5050
 RelaySyslog             | false
+RelaySyslogStartupOnly  | false
+RelaySyslogStartupTime  | 1m
 SyslogAddr              | 127.0.0.1:514
 ContainerLogsStdout     | false
 SendDockerLabels        | []
@@ -195,6 +197,15 @@ with `EXECUTOR_`.
  * **RelaySyslog**: Should we relay container logs to syslog? This is a bare UDP
    implementation suitable for loggers that don't care about syslog protocol.
    Logs will be sent in JSON format, using Logrus.
+
+ * **RelaySyslogStartupOnly**: Should we relay container logs to syslog only
+   for the startup duration? This is helpful for apps that do their own
+   syslogging but are not able to log during their startup process. The length
+   of time to relay logs is controlled by `RelaySyslogStartupTime`.
+
+ * **RelaySyslogStartupTime**: By itself this configuration item does nothing.
+   It controls the value for how long to log for when `RelaySyslogStartupOnly`
+   is set.
 
  * **SyslogAddr**: If `RelaySyslog` is true, we'll use this as the remote address
    for syslog logging.

--- a/executor_utils.go
+++ b/executor_utils.go
@@ -32,7 +32,7 @@ func (exec *sidecarExecutor) copyLogs(containerId string) {
 func (exec *sidecarExecutor) handleContainerLogs(containerId string,
 	labels map[string]string) {
 
-	if exec.config.RelaySyslog {
+	if exec.config.RelaySyslog || exec.config.RelaySyslogStartupOnly {
 		var output io.Writer
 		if exec.config.ContainerLogsStdout {
 			output = os.Stdout

--- a/log_relay.go
+++ b/log_relay.go
@@ -78,10 +78,8 @@ func (exec *sidecarExecutor) relayLogs(quitChan chan struct{},
 // is used for apps that do their lown logging when started, but might fail
 // during startup and need us to pump startup logs.
 func cancelAfterStartup(quitChan chan struct{}, startupTime time.Duration) {
-	select {
-	case <-time.After(startupTime):
-		close(quitChan)
-	}
+	<-time.After(startupTime)
+	close(quitChan)
 }
 
 // handleOneStream will process one data stream into logs

--- a/log_relay.go
+++ b/log_relay.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/Nitro/sidecar-executor/container"
 	"github.com/Nitro/sidecar-executor/loghooks"
@@ -66,7 +67,21 @@ func (exec *sidecarExecutor) relayLogs(quitChan chan struct{},
 	go exec.handleOneStream(quitChan, "stdout", logger, outrd)
 	go exec.handleOneStream(quitChan, "stderr", logger, errrd)
 
+	if exec.config.RelaySyslogStartupOnly {
+		go cancelAfterStartup(quitChan, exec.config.RelaySyslogStartupTime)
+	}
+
 	<-quitChan
+}
+
+// cancelAfterStartup will stop the log pump after RelaySyslogStartupTime. This
+// is used for apps that do their lown logging when started, but might fail
+// during startup and need us to pump startup logs.
+func cancelAfterStartup(quitChan chan struct{}, startupTime time.Duration) {
+	select {
+	case <-time.After(startupTime):
+		close(quitChan)
+	}
 }
 
 // handleOneStream will process one data stream into logs

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -109,6 +109,7 @@ func Test_relayLogs(t *testing.T) {
 				select {
 				case <-quitChan:
 					channelClosedSuccess = true
+				case <-time.After(10*time.Millisecond):
 				}
 			}()
 

--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -96,6 +96,29 @@ func Test_relayLogs(t *testing.T) {
 			So(exec.config.LogHostname, ShouldNotBeEmpty)
 			So(string(resultBytes), ShouldContainSubstring, `"Hostname":"`+exec.config.LogHostname)
 		})
+
+		Convey("shuts down after RelaySyslogStartupTime when configured", func() {
+			result, _ := os.OpenFile(tmpfn, os.O_RDWR|os.O_CREATE, 0644)
+			exec.config.RelaySyslogStartupOnly = true
+			exec.config.RelaySyslogStartupTime = 1 * time.Millisecond
+
+			// Attempt time-limited read from the channel. If we get a read,
+			// the channel closed.
+			var channelClosedSuccess bool
+			go func() {
+				select {
+				case <-quitChan:
+					channelClosedSuccess = true
+				}
+			}()
+
+			exec.relayLogs(quitChan, "deadbeef123123123", map[string]string{}, result)
+			exec.config.ContainerLogsStdout = true
+
+			So(channelClosedSuccess, ShouldBeTrue)
+			resultBytes, _ := ioutil.ReadFile(tmpfn)
+			So(resultBytes, ShouldNotBeEmpty)
+		})
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -55,11 +55,13 @@ type Config struct {
 	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`
 
 	// Syslogging options
-	RelaySyslog         bool     `envconfig:"RELAY_SYSLOG" default:"false"`
-	SyslogAddr          string   `envconfig:"SYSLOG_ADDR" default:"127.0.0.1:514"`
-	ContainerLogsStdout bool     `envconfig:"CONTAINER_LOGS_STDOUT" default:"false"`
-	SendDockerLabels    []string `envconfig:"SEND_DOCKER_LABELS" default:""`
-	LogHostname         string   `envconfig:"LOG_HOSTNAME"` // Name we log as
+	RelaySyslog            bool          `envconfig:"RELAY_SYSLOG" default:"false"`
+	RelaySyslogStartupOnly bool          `envconfig:"RELAY_SYSLOG_STARTUP_ONLY" default:"false"`
+	RelaySyslogStartupTime time.Duration `envconfig:"RELAY_SYSLOG_STARTUP_TIME" default:"1m"`
+	SyslogAddr             string        `envconfig:"SYSLOG_ADDR" default:"127.0.0.1:514"`
+	ContainerLogsStdout    bool          `envconfig:"CONTAINER_LOGS_STDOUT" default:"false"`
+	SendDockerLabels       []string      `envconfig:"SEND_DOCKER_LABELS" default:""`
+	LogHostname            string        `envconfig:"LOG_HOSTNAME"` // Name we log as
 }
 
 type Vault interface {
@@ -98,6 +100,8 @@ func logConfig(config Config) {
 	log.Infof(" * UseCpuShares:            %t", config.UseCpuShares)
 	log.Infof(" * MesosMasterPort:         %s", config.MesosMasterPort)
 	log.Infof(" * RelaySyslog:             %t", config.RelaySyslog)
+	log.Infof(" * RelaySyslogStartupOnly:  %t", config.RelaySyslogStartupOnly)
+	log.Infof(" * RelaySyslogStartupTime:  %s", config.RelaySyslogStartupTime.String())
 	log.Infof(" * SyslogAddr:              %s", config.SyslogAddr)
 	log.Infof(" * ContainerLogsStdout:     %t", config.ContainerLogsStdout)
 	log.Infof(" * SendDockerLabels:        %v", config.SendDockerLabels)


### PR DESCRIPTION
Some applications don't need log relaying because they do it themselves. However, in these cases it can sometimes be helpful to have the executor handle log relaying during the startup time for the app. This allows things like migrations and other startup errors to be logged to syslog, even when the application has failed to start.

This adds two configuration items, both described in the patch to the README. They allow precise configuration of this behavior and were simple to implement because of the existing `quitChan` implementation on the log pump.