### PR TITLE
Check for quit before processing logs

### DIFF
--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -109,7 +109,7 @@ func Test_relayLogs(t *testing.T) {
 				select {
 				case <-quitChan:
 					channelClosedSuccess = true
-				case <-time.After(10*time.Millisecond):
+				case <-time.After(10 * time.Millisecond):
 				}
 			}()
 


### PR DESCRIPTION
We were still processing one more log message after the quit channel was closed. On normal shutdown this was OK, but when we were quitting after the timer expired when configured to log only on startup, we were logging more more line that we should have. This fixes it by exiting first.