### PR TITLE
Modern Mesos can't do CommandInfo & ExecutorCommandInfo

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -166,8 +166,9 @@ func ConfigForTask(taskInfo *mesos.TaskInfo, forceCpuLimit bool, forceMemoryLimi
 	labels := LabelsForTask(taskInfo)
 
 	var command []string
-	if taskInfo.Command != nil && len(taskInfo.Command.Arguments) > 0 {
-		command = taskInfo.Command.Arguments
+	if _, ok := labels["executor.ShellCommand"]; ok {
+		command = []string{labels["executor.ShellCommand"]}
+		delete(labels, "executor.ShellCommand")
 	}
 
 	config := &docker.CreateContainerOptions{

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -180,6 +180,9 @@ func Test_ConfigGeneration(t *testing.T) {
 		volumeDriverValue := "driver_test"
 		capDropValue := "NET_ADMIN"
 
+		shellCommand := `/bin/bash -c 'echo beowulf'`
+		shellCommandLabel := "executor.ShellCommand=" + shellCommand
+
 		svcName := "dev-test-app"
 		svcNameLabel := "ServiceName=" + svcName
 
@@ -228,6 +231,10 @@ func Test_ConfigGeneration(t *testing.T) {
 						{
 							Key:   "label",
 							Value: envNameLabel,
+						},
+						{
+							Key:   "label",
+							Value: shellCommandLabel,
 						},
 						{
 							Key:   "cap-add",
@@ -414,7 +421,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("uses the command when it's set", func() {
-			So(opts.Config.Cmd, ShouldContain, "date")
+			So(opts.Config.Cmd, ShouldContain, shellCommand)
 		})
 	})
 }


### PR DESCRIPTION
It used to be that you could pass both a `CommandInfo` and an `ExecutorCommandInfo` at the same time. That hasn't worked for awhile. In order to pass custom commands to our executor we need another mechanism. We could use `EXECUTOR` env vars, but then the command lives in a part of the config far away from the container info. Instead, this PR creates a new Docker label that will *not be sent to Docker* called `executor.ShellCommand` that will get put into the Docker container's `Cmd` field as a string.