### PR TITLE
Allow CLI args for command we pass

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -11,7 +11,6 @@ import (
 // executor.
 func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 	taskID := taskInfo.GetTaskID()
-	log.Infof("Launching task %s with command '%s'", taskInfo.GetName(), taskInfo.Command.GetValue())
 	log.Info("Task ID ", taskID.GetValue())
 
 	// We need to tell the scheduler that we started the task

--- a/container/container.go
+++ b/container/container.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/avast/retry-go"
+	retry "github.com/avast/retry-go"
 	docker "github.com/fsouza/go-dockerclient"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/pborman/uuid"
@@ -167,9 +167,11 @@ func ConfigForTask(taskInfo *mesos.TaskInfo, forceCpuLimit bool, forceMemoryLimi
 
 	var command []string
 	if _, ok := labels["executor.ShellCommand"]; ok {
-		command = []string{labels["executor.ShellCommand"]}
+		command = strings.Split(labels["executor.ShellCommand"], " ")
 		delete(labels, "executor.ShellCommand")
 	}
+
+	log.Infof("Launching task %s with command '%s'", taskInfo.GetName(), command)
 
 	config := &docker.CreateContainerOptions{
 		Name: GetContainerName(&taskInfo.TaskID),

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,7 +181,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		volumeDriverValue := "driver_test"
 		capDropValue := "NET_ADMIN"
 
-		shellCommand := `/bin/bash -c 'echo beowulf'`
+		shellCommand := `make build beowulf`
 		shellCommandLabel := "executor.ShellCommand=" + shellCommand
 
 		svcName := "dev-test-app"
@@ -421,7 +422,11 @@ func Test_ConfigGeneration(t *testing.T) {
 		})
 
 		Convey("uses the command when it's set", func() {
-			So(opts.Config.Cmd, ShouldContain, shellCommand)
+			cmdParts := strings.Split(shellCommand, " ")
+			So(len(opts.Config.Cmd), ShouldEqual, 3)
+			for i, part := range cmdParts {
+				So(opts.Config.Cmd[i], ShouldResemble, part)
+			}
 		})
 	})
 }


### PR DESCRIPTION
The previous solution to arbitrary commands didn't support *any* CLI args. This solution is not great but supports simple args as long as they don't themselves contain spaces.